### PR TITLE
fix(jvm target): adding amd64 check for targets

### DIFF
--- a/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
@@ -49,18 +49,18 @@ internal actual class Zenoh private actual constructor() {
 
             val target = when {
                 osName.contains("win") -> when {
-                    osArch.contains("x86_64") -> Target.WINDOWS_X86_64_MSVC
+                    osArch.contains("x86_64") || osArch.contains("amd64") -> Target.WINDOWS_X86_64_MSVC
                     else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
                 }
 
                 osName.contains("mac") -> when {
-                    osArch.contains("x86_64") -> Target.APPLE_X86_64
+                    osArch.contains("x86_64") || osArch.contains("amd64") -> Target.APPLE_X86_64
                     osArch.contains("aarch64") -> Target.APPLE_AARCH64
                     else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
                 }
 
                 osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> when {
-                    osArch.contains("x86_64") -> Target.LINUX_X86_64
+                    osArch.contains("x86_64") || osArch.contains("amd64") -> Target.LINUX_X86_64
                     osArch.contains("aarch64") -> Target.LINUX_AARCH64
                     else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
                 }


### PR DESCRIPTION
In openjdk, the os.arch is reported as amd64 for x86_64 system.