### PR TITLE
build(publication): modifying workflows to publish snapshot packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,26 @@ jobs:
     steps:
       - name: Check whether all jobs pass
         run: echo '${{ toJson(needs) }}' | jq -e 'all(.result == "success")'
+
+  # Publish snapshot packages. These jobs will only be triggered when the CI is executed on main.
+  publish_jvm_snapshot_package:
+    name: Publish JVM snapshot package
+    if: github.ref == 'refs/heads/main'
+    needs: ci
+    uses: ./.github/workflows/publish_jvm.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: 0.11.0-rc-SNAPSHOT
+
+  publish_android_snapshot_package:
+    name: Publish Android snapshot package
+    if: github.ref == 'refs/heads/main'
+    needs: ci
+    uses: ./.github/workflows/publish_android.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: 0.11.0-rc-SNAPSHOT

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -3,6 +3,13 @@ name: Publish Android
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: 'The publication version'
+        default: '0.11.0-rc'
   workflow_dispatch:
 
 env:
@@ -52,6 +59,6 @@ jobs:
       - name: Gradle Publish Android Package
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishAndroidReleasePublicationToGithubPackagesRepository
+          arguments: publishAndroidReleasePublicationToGithubPackagesRepository -PzkVersion=${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_jvm.yml
+++ b/.github/workflows/publish_jvm.yml
@@ -3,6 +3,13 @@ name: Publish JVM
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        description: 'The publication version'
+        default: '0.11.0-rc'
   workflow_dispatch:
 
 env:
@@ -156,6 +163,6 @@ jobs:
       - name: Gradle Publish JVM Package
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishJvmPublicationToGithubPackagesRepository
+          arguments: publishJvmPublicationToGithubPackagesRepository -PzkVersion=${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -13,7 +13,7 @@
 //
 
 group = "io.zenoh"
-version = "0.11.0-dev"
+version = project.findProperty("zkVersion") as String? ?: "0.11.0-dev"
 
 plugins {
     id("com.android.library")


### PR DESCRIPTION
This PR modifies the Github workflows in order to trigger the publication of snapshot packages for both JVM and Android when the CI is run an is successful on main. This way changes and fixes during the development phase are accessible to users before a new release performed.