### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -62,6 +62,7 @@ class ZPub(private val emptyArgs: Boolean) : CliktCommand(
                         println("Declaring publisher on '$keyExpr'...")
                         session.declarePublisher(keyExpr).res().onSuccess { pub ->
                             pub.use {
+                                println("Press CTRL-C to quit...")
                                 val attachment = attachment?.let { decodeAttachment(it) }
                                 var idx = 0
                                 while (true) {

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -67,14 +67,15 @@ class ZPub(private val emptyArgs: Boolean) : CliktCommand(
                                 var idx = 0
                                 while (true) {
                                     Thread.sleep(1000)
-                                    println(
-                                        "Putting Data ('$keyExpr': '[${
+                                    val payload = "[${
                                             idx.toString().padStart(4, ' ')
-                                        }] $value')..."
+                                        }] $value"
+                                    println(
+                                        "Putting Data ('$keyExpr': '$payload')..."
                                     )
                                     attachment?.let {
-                                        pub.put(value).withAttachment(attachment).res()
-                                    } ?: let { pub.put(value).res() }
+                                        pub.put(payload).withAttachment(attachment).res()
+                                    } ?: let { pub.put(payload).res() }
                                     idx++
                                 }
                             }

--- a/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
@@ -87,9 +87,9 @@ class ZPubThr(private val emptyArgs: Boolean) : CliktCommand(
                             var count: Long = 0
                             var start = System.currentTimeMillis()
                             val number = number.toLong()
+                            println("Press CTRL-C to quit...")
                             while (true) {
                                 pub.put(value).res().getOrThrow()
-
                                 if (statsPrint) {
                                     if (count < number) {
                                         count++
@@ -100,7 +100,6 @@ class ZPubThr(private val emptyArgs: Boolean) : CliktCommand(
                                         start = System.currentTimeMillis()
                                     }
                                 }
-
                             }
                         }
                     }

--- a/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
@@ -64,6 +64,7 @@ class ZQueryable(private val emptyArgs: Boolean) : CliktCommand(
                         println("Declaring Queryable")
                         session.declareQueryable(keyExpr).res().onSuccess { queryable ->
                             queryable.use {
+                                println("Press CTRL-C to quit...")
                                 queryable.receiver?.let { receiverChannel -> //  The default receiver is a Channel we can process on a coroutine.
                                     runBlocking {
                                         handleRequests(receiverChannel, keyExpr)

--- a/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
@@ -61,7 +61,7 @@ class ZQueryable(private val emptyArgs: Boolean) : CliktCommand(
             session.use {
                 key.intoKeyExpr().onSuccess { keyExpr ->
                     keyExpr.use {
-                        println("Declaring Queryable")
+                        println("Declaring Queryable on " + key + "...")
                         session.declareQueryable(keyExpr).res().onSuccess { queryable ->
                             queryable.use {
                                 println("Press CTRL-C to quit...")

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -54,6 +54,7 @@ class ZSub(private val emptyArgs: Boolean) : CliktCommand(
                         println("Declaring Subscriber on '$keyExpr'...")
                         session.declareSubscriber(keyExpr).bestEffort().res().onSuccess { subscriber ->
                             subscriber.use {
+                                println("Press CTRL-C to quit...")
                                 runBlocking {
                                     val receiver = subscriber.receiver!!
                                     val iterator = receiver.iterator()

--- a/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
@@ -104,9 +104,11 @@ class ZSubThr(private val emptyArgs: Boolean) : CliktCommand(
                 println("Opening Session")
                 Session.open(config).onSuccess {
                     it.use { session ->
+                        println("Press CTRL-C to quit...")
                         subscriber =
                             session.declareSubscriber(keyExpr).reliable().with { listener(number) }.res().getOrThrow()
                         while (subscriber.isValid()) {/* Keep alive the subscriber until the test is done. */
+                            Thread.sleep(1000)
                         }
                     }
                 }


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects.

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.

Related PRs:
- https://github.com/eclipse-zenoh/zenoh/pull/768
- https://github.com/eclipse-zenoh/zenoh-c/pull/255
- https://github.com/eclipse-zenoh/zenoh-cpp/pull/103
- https://github.com/eclipse-zenoh/zenoh-java/pull/45
- https://github.com/eclipse-zenoh/zenoh-pico/pull/359
- https://github.com/eclipse-zenoh/zenoh-python/pull/150