### PR TITLE
fix(mem leak): user attachment bytes not being freed

### DIFF
--- a/zenoh-jni/src/query.rs
+++ b/zenoh-jni/src/query.rs
@@ -293,6 +293,9 @@ pub(crate) fn on_query(
     _ = env
         .delete_local_ref(payload)
         .map_err(|err| log::error!("Error deleting local ref: {}", err));
+    _ = env
+        .delete_local_ref(attachment_bytes)
+        .map_err(|err| log::error!("Error deleting local ref: {}", err));
     result
 }
 

--- a/zenoh-jni/src/reply.rs
+++ b/zenoh-jni/src/reply.rs
@@ -103,6 +103,9 @@ fn on_reply_success(
     _ = env
         .delete_local_ref(byte_array)
         .map_err(|err| log::debug!("Error deleting local ref: {}", err));
+    _ = env
+        .delete_local_ref(attachment_bytes)
+        .map_err(|err| log::debug!("Error deleting local ref: {}", err));
     result
 }
 

--- a/zenoh-jni/src/subscriber.rs
+++ b/zenoh-jni/src/subscriber.rs
@@ -154,6 +154,9 @@ pub(crate) unsafe fn declare_subscriber(
             _ = env
                 .delete_local_ref(byte_array)
                 .map_err(|err| log::debug!("Error deleting local ref: {}", err));
+            _ = env
+                .delete_local_ref(attachment_bytes)
+                .map_err(|err| log::debug!("Error deleting local ref: {}", err));
         })
         .reliability(reliability)
         .res();


### PR DESCRIPTION
User attachment JNI byte array is not freed, causing a memory leak.