### PR TITLE
Adding command line arguments for Kotlin examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,11 +40,11 @@ Options:
 
 ```
 
-The connect and listen parameters (that are common to all the examples) accept multiple inputs separated by a whitespace.
+The connect and listen parameters (that are common to all the examples) accept multiple repeated inputs.
 For instance:
 
 ```bash
-  gradle ZPub --args="-l tcp/localhost:7447 tcp/localhost:7448 tcp/localhost:7449"
+  gradle ZPub --args="-l tcp/localhost:7447 -l tcp/localhost:7448 -l tcp/localhost:7449"
 ```
 
 There is the possibility to provide a Zenoh config file as follows

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@
 for instance
 
 ```bash
-  gralde ZPub --args="-h"
+  gradle ZPub --args="-h"
 ```
 
 will return
@@ -48,7 +48,7 @@ For instance:
 ```
 
 There is the possibility to provide a Zenoh config file as follows
-```bash 
+```bash
   gradle ZPub --args="-c path/to/config.json5"
 ```
 
@@ -62,7 +62,7 @@ One last comment regarding Zenoh logging for the examples, remember it can be en
 
 where `<level>` can be either `info`, `trace`, `debug`, `warn` or `error`.
 
----- 
+----
 
 ## Examples description
 
@@ -110,7 +110,7 @@ or
 ```bash
 gradle ZGet --args="-s demo/example/get"
 ```
-    
+
 ### ZPut
 
 Puts a path/value into Zenoh.
@@ -137,7 +137,7 @@ Usage:
 gradle ZDelete
 ```
 
-or 
+or
 
 ```bash
 gradle ZDelete --args="-k demo/example/delete"

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,11 +7,60 @@
 
 
 ```bash
-  ./gradle <example>
+  gradle <example> --args="<arguments>"
 ```
 
-:warning: Passing arguments to these examples has not been enabled yet for this first version. Altering the Zenoh
-configuration for these examples must be done programmatically. :warning:
+for instance
+
+```bash
+  gralde ZPub --args="-h"
+```
+
+will return
+```bash
+> Task :examples:ZPub
+Usage: zpub [<options>]
+
+  Zenoh Pub example
+
+Options:
+  -k, --key=<key>             The key expression to write to [default:
+                              demo/example/zenoh-kotlin-pub]
+  -c, --config=<config>       A configuration file.
+  -e, --connect=<connect>...  Endpoints to connect to.
+  -l, --listen=<listen>...    Endpoints to listen on.
+  -m, --mode=<mode>           The session mode. Default: peer. Possible values:
+                              [peer, client, router]
+  -v, --value=<value>         The value to write. [Default: "Pub from Kotlin!"]
+  -a, --attach=<attach>       The attachments to add to each put. The key-value
+                              pairs are &-separated, and = serves as the
+                              separator between key and value.
+  --no-multicast-scouting     Disable the multicast-based scouting mechanism.
+  -h, --help                  Show this message and exit
+
+```
+
+The connect and listen parameters (that are common to all the examples) accept multiple inputs separated by a whitespace.
+For instance:
+
+```bash
+  gradle ZPub --args="-l tcp/localhost:7447 tcp/localhost:7448 tcp/localhost:7449"
+```
+
+There is the possibility to provide a Zenoh config file as follows
+```bash 
+  gradle ZPub --args="-c path/to/config.json5"
+```
+
+In that case, any other provided configuration parameters through the command line interface will not be taken into consideration.
+
+One last comment regarding Zenoh logging for the examples, remember it can be enabled through the `zenoh.logger` property as follows:
+
+```bash
+  gradle ZPub -Pzenoh.logger=<level>
+```
+
+where `<level>` can be either `info`, `trace`, `debug`, `warn` or `error`.
 
 ---- 
 
@@ -25,7 +74,11 @@ The path/value will be received by all matching subscribers, for instance the [Z
 Usage:
 
 ```bash
-./gradle ZPub
+gradle ZPub
+```
+or
+```bash
+gradle ZPub --args="-k demo/example/test -v 'hello world'"
 ```
 
 ### ZSub
@@ -36,7 +89,11 @@ the subscriber's key expression, and will print this notification.
 Usage:
 
 ```bash
-./gradle ZSub
+gradle ZSub
+```
+or
+```bash
+gradle ZSub --args="-k demo/example/test"
 ```
 
 ### ZGet
@@ -46,7 +103,12 @@ The queryables with a matching path or selector (for instance [ZQueryable](#zque
 will receive this query and reply with paths/values that will be received by the query callback.
 
 ```bash
-./gradle ZGet
+gradle ZGet
+```
+or
+
+```bash
+gradle ZGet --args="-s demo/example/get"
 ```
     
 ### ZPut
@@ -57,7 +119,13 @@ The path/value will be received by all matching subscribers, for instance the [Z
 Usage:
 
 ```bash
-./gradle ZPut
+gradle ZPut
+```
+
+or
+
+```bash
+gradle ZPut --args="-k demo/example/put -v 'Put from Kotlin!'"
 ```
 
 ### ZDelete
@@ -66,7 +134,13 @@ Performs a Delete operation into a path/value into Zenoh.
 Usage:
 
 ```bash
-./gradle ZDelete
+gradle ZDelete
+```
+
+or 
+
+```bash
+gradle ZDelete --args="-k demo/example/delete"
 ```
 
 ### ZQueryable
@@ -78,7 +152,13 @@ with a selector that matches the key expression, and will return a value to the 
 Usage:
 
 ```bash
-./gradle ZQueryable
+gradle ZQueryable
+```
+
+or
+
+```bash
+gradle ZQueryable --args="-k demo/example/query"
 ```
 
 ### ZPubThr & ZSubThr
@@ -90,11 +170,11 @@ put operations and a subscriber receiving notifications of those puts.
 Subscriber usage:
 
 ```bash
-./gradle ZSubThr
+gradle ZSubThr
 ```
 
 Publisher usage:
 
 ```bash
-./gradle ZPubThr
+gradle ZPubThr <payload_size>
 ```

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     kotlin("jvm")
+    kotlin("plugin.serialization")
 }
 
 kotlin {
@@ -24,6 +25,8 @@ dependencies {
     implementation(project(":zenoh-kotlin"))
     implementation("commons-net:commons-net:3.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("com.github.ajalt.clikt:clikt:4.2.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
 }
 
 tasks {

--- a/examples/src/main/kotlin/io.zenoh/Config.kt
+++ b/examples/src/main/kotlin/io.zenoh/Config.kt
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-package io.zenoh.config
+package io.zenoh
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName

--- a/examples/src/main/kotlin/io.zenoh/Config.kt
+++ b/examples/src/main/kotlin/io.zenoh/Config.kt
@@ -52,8 +52,8 @@ data class Multicast(
 internal fun loadConfig(
     emptyArgs: Boolean,
     configFile: String?,
-    connectEndpoints: List<String>?,
-    listenEndpoints: List<String>?,
+    connectEndpoints: List<String>,
+    listenEndpoints: List<String>,
     noMulticastScouting: Boolean,
     mode: String?
 ): Config {
@@ -61,8 +61,8 @@ internal fun loadConfig(
         Config.default()
     } else {
         configFile?.let { Config.from(Path(it)) } ?: run {
-            val connect = connectEndpoints?.let { Connect(it) }
-            val listen = listenEndpoints?.let { Listen(listenEndpoints) }
+            val connect = Connect(connectEndpoints)
+            val listen = Listen(listenEndpoints)
             val scouting = Scouting(Multicast(!noMulticastScouting))
             val configData = ConfigData(connect, listen, mode, scouting)
             val jsonConfig = Json.encodeToJsonElement(configData)

--- a/examples/src/main/kotlin/io.zenoh/Config.kt
+++ b/examples/src/main/kotlin/io.zenoh/Config.kt
@@ -14,41 +14,65 @@
 
 package io.zenoh
 
+import io.zenoh.sample.Attachment
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
 
 @Serializable
 data class ConfigData(
-    @SerialName("connect")
-    var connect: Connect? = null,
-    @SerialName("listen")
-    var listen: Listen? = null,
-    @SerialName("mode")
-    var mode: String? = null,
-    @SerialName("scouting")
-    var scouting: Scouting? = null,
+    @SerialName("connect") var connect: Connect? = null,
+    @SerialName("listen") var listen: Listen? = null,
+    @SerialName("mode") var mode: String? = null,
+    @SerialName("scouting") var scouting: Scouting? = null,
 )
 
 @Serializable
 data class Connect(
-    @SerialName("endpoints")
-    var endpoints: List<String>
+    @SerialName("endpoints") var endpoints: List<String>
 )
 
 @Serializable
 data class Listen(
-    @SerialName("endpoints")
-    var endpoints: List<String>
+    @SerialName("endpoints") var endpoints: List<String>
 )
 
 @Serializable
 data class Scouting(
-    @SerialName("multicast")
-    var multicast: Multicast,
+    @SerialName("multicast") var multicast: Multicast,
 )
 
 @Serializable
 data class Multicast(
-    @SerialName("enabled")
-    var enabled: Boolean,
+    @SerialName("enabled") var enabled: Boolean,
 )
+
+internal fun loadConfig(
+    emptyArgs: Boolean,
+    configFile: String?,
+    connectEndpoints: List<String>?,
+    listenEndpoints: List<String>?,
+    noMulticastScouting: Boolean,
+    mode: String?
+): Config {
+    val config = if (emptyArgs) {
+        Config.default()
+    } else {
+        configFile?.let { Config.from(Path(it)) } ?: run {
+            val connect = connectEndpoints?.let { Connect(it) }
+            val listen = listenEndpoints?.let { Listen(listenEndpoints) }
+            val scouting = Scouting(Multicast(!noMulticastScouting))
+            val configData = ConfigData(connect, listen, mode, scouting)
+            val jsonConfig = Json.encodeToJsonElement(configData)
+            Config.from(jsonConfig)
+        }
+    }
+    return config
+}
+
+internal fun decodeAttachment(attachment: String): Attachment {
+    val pairs = attachment.split("&").map { it.split("=").let { (k, v) -> k.toByteArray() to v.toByteArray() } }
+    return Attachment.Builder().addAll(pairs).res()
+}

--- a/examples/src/main/kotlin/io.zenoh/ZDelete.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZDelete.kt
@@ -19,7 +19,6 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement

--- a/examples/src/main/kotlin/io.zenoh/ZDelete.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZDelete.kt
@@ -14,18 +14,72 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
 
-fun main() {
-    println("Opening session...")
-    Session.open().onSuccess { session ->
-        session.use {
-            "demo/example/zenoh-kotlin-put".intoKeyExpr().onSuccess { keyExpr ->
-                keyExpr.use {
-                    println("Deleting resources matching '$keyExpr'...")
-                    session.delete(keyExpr).res()
+class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Delete example"
+) {
+
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val key by option(
+        "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"
+    ).default("demo/example/zenoh-kotlin-put")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+        val config = loadConfig()
+
+        println("Opening session...")
+        Session.open(config).onSuccess { session ->
+            session.use {
+                key.intoKeyExpr().onSuccess { keyExpr ->
+                    keyExpr.use {
+                        println("Deleting resources matching '$keyExpr'...")
+                        session.delete(keyExpr).res()
+                    }
                 }
             }
         }
     }
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
 }
+
+fun main(args: Array<String>) = ZDelete(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZDelete.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZDelete.kt
@@ -15,22 +15,19 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import io.zenoh.keyexpr.intoKeyExpr
 
 class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Delete example"
 ) {
 
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
     private val key by option(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"

--- a/examples/src/main/kotlin/io.zenoh/ZDelete.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZDelete.kt
@@ -17,27 +17,24 @@ package io.zenoh
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.varargValues
 import io.zenoh.keyexpr.intoKeyExpr
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlin.io.path.Path
 
 class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Delete example"
 ) {
 
-    private val connect: List<String> by option(
+    private val connect: List<String>? by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).multiple()
+    ).varargValues()
+    private val listen: List<String>? by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).varargValues()
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
     private val key by option(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"
     ).default("demo/example/zenoh-kotlin-put")
-    private val listen: List<String> by option(
-        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).multiple()
     private val mode by option(
         "-m",
         "--mode",
@@ -49,7 +46,7 @@ class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
     ).flag(default = false)
 
     override fun run() {
-        val config = loadConfig()
+        val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting,mode)
 
         println("Opening session...")
         Session.open(config).onSuccess { session ->
@@ -62,22 +59,6 @@ class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
                 }
             }
         }
-    }
-
-    private fun loadConfig(): Config {
-        val config = if (emptyArgs) {
-            Config.default()
-        } else {
-            configFile?.let { Config.from(Path(it)) } ?: let {
-                val connect = if (connect.isEmpty()) null else Connect(connect)
-                val listen = if (listen.isEmpty()) null else Listen(listen)
-                val scouting = Scouting(Multicast(!noMulticastScouting))
-                val configData = ConfigData(connect, listen, mode, scouting)
-                val jsonConfig = Json.encodeToJsonElement(configData)
-                Config.from(jsonConfig)
-            }
-        }
-        return config
     }
 }
 

--- a/examples/src/main/kotlin/io.zenoh/ZGet.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZGet.kt
@@ -14,27 +14,86 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.long
+import io.zenoh.config.*
+import io.zenoh.query.QueryTarget
 import io.zenoh.query.Reply
 import io.zenoh.selector.intoSelector
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
 import java.time.Duration
+import kotlin.io.path.Path
 
-fun main() {
-    val timeout = Duration.ofMillis(1000)
-    Session.open().onSuccess { session ->
-        session.use {
-            "demo/example/**".intoSelector().onSuccess { selector ->
-                selector.use {
-                    session.get(selector).timeout(timeout).res().onSuccess {
-                        runBlocking {
-                            val iterator = it!!.iterator()
-                            while (iterator.hasNext()) {
-                                val reply = iterator.next()
-                                if (reply is Reply.Success) {
-                                    println("Received ('${reply.sample.keyExpr}': '${reply.sample.value}')")
-                                } else {
-                                    reply as Reply.Error
-                                    println("Received (ERROR: '${reply.error}')")
+class ZGet(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Get example"
+) {
+
+    private val selector by option(
+        "-s",
+        "--selector",
+        help = "The selection of resources to query [default: demo/example/**]",
+        metavar = "selector"
+    ).default("demo/example/**")
+    private val value by option(
+        "-v", "--value", help = "An optional value to put in the query.", metavar = "value"
+    )
+    private val target by option(
+        "-t",
+        "--target",
+        help = "The target queryables of the query. Default: BEST_MATCHING. " + "[possible values: BEST_MATCHING, ALL, ALL_COMPLETE]",
+        metavar = "target"
+    )
+    private val timeout by option(
+        "-o", "--timeout", help = "The query timeout in milliseconds [default: 10000]", metavar = "timeout"
+    ).long().default(10000)
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+
+    override fun run() {
+        val config = loadConfig()
+
+        Session.open(config).onSuccess { session ->
+            session.use {
+                selector.intoSelector().onSuccess { selector ->
+                    selector.use {
+                        val getBuilder = session.get(selector).apply {
+                            target?.let {
+                                target(QueryTarget.valueOf(it.uppercase()))
+                            }
+                            timeout(Duration.ofMillis(timeout))
+                        }
+                        getBuilder.res().onSuccess {
+                            runBlocking {
+                                val iterator = it!!.iterator()
+                                while (iterator.hasNext()) {
+                                    val reply = iterator.next()
+                                    if (reply is Reply.Success) {
+                                        println("Received ('${reply.sample.keyExpr}': '${reply.sample.value}')")
+                                    } else {
+                                        reply as Reply.Error
+                                        println("Received (ERROR: '${reply.error}')")
+                                    }
                                 }
                             }
                         }
@@ -43,5 +102,22 @@ fun main() {
             }
         }
     }
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
 }
 
+fun main(args: Array<String>) = ZGet(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZGet.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZGet.kt
@@ -20,7 +20,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
-import io.zenoh.config.*
 import io.zenoh.query.ConsolidationMode
 import io.zenoh.query.QueryTarget
 import io.zenoh.query.Reply

--- a/examples/src/main/kotlin/io.zenoh/ZGet.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZGet.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.long
 import io.zenoh.query.ConsolidationMode
 import io.zenoh.query.QueryTarget
@@ -56,12 +53,12 @@ class ZGet(private val emptyArgs: Boolean) : CliktCommand(
         help = "The session mode. Default: peer. Possible values: [peer, client, router]",
         metavar = "mode"
     ).default("peer")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val attachment by option(
         "-a",
         "--attach",

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -14,33 +14,104 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
+import io.zenoh.sample.Attachment
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
 
-fun main() {
-    println("Opening session...")
-    Session.open().onSuccess { session ->
-        session.use {
-            "demo/example/zenoh-kotlin-pub".intoKeyExpr().onSuccess { keyExpr ->
-                keyExpr.use {
-                    println("Declaring publisher on '$keyExpr'...")
-                    session.declarePublisher(keyExpr).res().onSuccess { pub ->
-                        pub.use {
-                            var idx = 0
-                            while (true) {
-                                Thread.sleep(1000)
-                                val payload = "Pub from Kotlin!"
-                                println(
-                                    "Putting Data ('$keyExpr': '[${
-                                        idx.toString().padStart(4, ' ')
-                                    }] $payload')..."
-                                )
-                                pub.put(payload).res()
-                                idx++
+class ZPub(private val defaultConfig: Boolean) : CliktCommand(
+    help = "Zenoh Pub example"
+) {
+
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val key by option(
+        "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-pub]", metavar = "key"
+    ).default("demo/example/zenoh-kotlin-pub")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val value by option(
+        "-v", "--value", help = "The value to write. [Default: \"Pub from Kotlin!\"]", metavar = "value"
+    ).default("Pub from Kotlin!")
+    private val attachment by option(
+        "-a",
+        "--attach",
+        help = "The attachments to add to each put. The key-value pairs are &-separated, and = serves as the separator between key and value.",
+        metavar = "attach"
+    )
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+        val config = loadConfig()
+
+        println("Opening session...")
+        Session.open(config).onSuccess { session ->
+            session.use {
+                key.intoKeyExpr().onSuccess { keyExpr ->
+                    keyExpr.use {
+                        println("Declaring publisher on '$keyExpr'...")
+                        session.declarePublisher(keyExpr).res().onSuccess { pub ->
+                            pub.use {
+                                val attachment = attachment?.let { decodeAttachment(it) }
+                                var idx = 0
+                                while (true) {
+                                    Thread.sleep(1000)
+                                    println(
+                                        "Putting Data ('$keyExpr': '[${
+                                            idx.toString().padStart(4, ' ')
+                                        }] $value')..."
+                                    )
+                                    attachment?.let {
+                                        pub.put(value).withAttachment(attachment).res()
+                                    } ?: let { pub.put(value).res() }
+                                    idx++
+                                }
                             }
                         }
                     }
                 }
             }
+        }.onFailure { exception -> println(exception.message) }
+    }
+
+    private fun loadConfig(): Config {
+        val config = if (defaultConfig) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
         }
+        return config
+    }
+
+    private fun decodeAttachment(attachment: String): Attachment {
+        val pairs = attachment.split("&").map { it.split("=").let { (k, v) -> k.toByteArray() to v.toByteArray() } }
+        return Attachment.Builder().addAll(pairs).res()
     }
 }
+
+fun main(args: Array<String>) = ZPub(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlin.io.path.Path
 
-class ZPub(private val defaultConfig: Boolean) : CliktCommand(
+class ZPub(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Pub example"
 ) {
 
@@ -93,7 +93,7 @@ class ZPub(private val defaultConfig: Boolean) : CliktCommand(
     }
 
     private fun loadConfig(): Config {
-        val config = if (defaultConfig) {
+        val config = if (emptyArgs) {
             Config.default()
         } else {
             configFile?.let { Config.from(Path(it)) } ?: let {

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -17,28 +17,24 @@ package io.zenoh
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.varargValues
 import io.zenoh.keyexpr.intoKeyExpr
-import io.zenoh.sample.Attachment
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlin.io.path.Path
 
 class ZPub(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Pub example"
 ) {
 
-    private val connect: List<String> by option(
-        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).multiple()
-    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
     private val key by option(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-pub]", metavar = "key"
     ).default("demo/example/zenoh-kotlin-pub")
-    private val listen: List<String> by option(
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val connect: List<String>? by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).varargValues()
+    private val listen: List<String>? by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).multiple()
+    ).varargValues()
     private val mode by option(
         "-m",
         "--mode",
@@ -59,7 +55,7 @@ class ZPub(private val emptyArgs: Boolean) : CliktCommand(
     ).flag(default = false)
 
     override fun run() {
-        val config = loadConfig()
+        val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting,mode)
 
         println("Opening session...")
         Session.open(config).onSuccess { session ->
@@ -89,27 +85,6 @@ class ZPub(private val emptyArgs: Boolean) : CliktCommand(
                 }
             }
         }.onFailure { exception -> println(exception.message) }
-    }
-
-    private fun loadConfig(): Config {
-        val config = if (emptyArgs) {
-            Config.default()
-        } else {
-            configFile?.let { Config.from(Path(it)) } ?: let {
-                val connect = if (connect.isEmpty()) null else Connect(connect)
-                val listen = if (listen.isEmpty()) null else Listen(listen)
-                val scouting = Scouting(Multicast(!noMulticastScouting))
-                val configData = ConfigData(connect, listen, mode, scouting)
-                val jsonConfig = Json.encodeToJsonElement(configData)
-                Config.from(jsonConfig)
-            }
-        }
-        return config
-    }
-
-    private fun decodeAttachment(attachment: String): Attachment {
-        val pairs = attachment.split("&").map { it.split("=").let { (k, v) -> k.toByteArray() to v.toByteArray() } }
-        return Attachment.Builder().addAll(pairs).res()
     }
 }
 

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -19,7 +19,6 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.sample.Attachment
 import kotlinx.serialization.json.Json

--- a/examples/src/main/kotlin/io.zenoh/ZPub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPub.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import io.zenoh.keyexpr.intoKeyExpr
 
 class ZPub(private val emptyArgs: Boolean) : CliktCommand(
@@ -29,12 +26,12 @@ class ZPub(private val emptyArgs: Boolean) : CliktCommand(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-pub]", metavar = "key"
     ).default("demo/example/zenoh-kotlin-pub")
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val mode by option(
         "-m",
         "--mode",

--- a/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
@@ -17,10 +17,7 @@ package io.zenoh
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.default
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.boolean
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.ulong
@@ -54,12 +51,12 @@ class ZPubThr(private val emptyArgs: Boolean) : CliktCommand(
     ).ulong().default(100000u)
     private val statsPrint by option("-t", "--print", help = "Print the statistics").boolean().default(true)
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val mode by option(
         "-m",
         "--mode",

--- a/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
@@ -24,7 +24,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.boolean
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.ulong
-import io.zenoh.config.*
 import io.zenoh.prelude.KnownEncoding
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.Encoding

--- a/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
@@ -14,33 +14,123 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.default
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.boolean
+import com.github.ajalt.clikt.parameters.types.int
+import com.github.ajalt.clikt.parameters.types.ulong
+import io.zenoh.config.*
 import io.zenoh.prelude.KnownEncoding
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.Encoding
 import io.zenoh.publication.CongestionControl
+import io.zenoh.publication.Priority
 import io.zenoh.value.Value
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
 
-fun main() {
-    val size = 8
-    val data = ByteArray(size)
-    for (i in 0..<size) {
-        data[i] = (i % 10).toByte()
-    }
-    val value = Value(data, Encoding(KnownEncoding.EMPTY))
-    Session.open().onSuccess {
-        it.use { session ->
-            session
-                .declarePublisher("test/thr".intoKeyExpr().getOrThrow())
-                .congestionControl(CongestionControl.BLOCK)
-                .res()
-                .onSuccess { pub ->
-                    pub.use {
-                        println("Publisher declared on test/thr.")
-                        while (true) {
-                            pub.put(value).res()
+class ZPubThr(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Throughput example"
+) {
+
+    private val payloadSize by argument(
+        "payload_size",
+        help = "Sets the size of the payload to publish [Default: 8]"
+    ).int().default(8)
+
+    private val priorityInput by option(
+        "-p",
+        "--priority",
+        help = "Priority for sending data",
+        metavar = "priority"
+    ).int()
+    private val number by option(
+        "-n",
+        "--number",
+        help = "Number of messages in each throughput measurements [default: 100000]",
+        metavar = "number"
+    ).ulong().default(100000u)
+    private val statsPrint by option("-t", "--print", help = "Print the statistics").boolean().default(true)
+
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+        val data = ByteArray(payloadSize)
+        for (i in 0..<payloadSize) {
+            data[i] = (i % 10).toByte()
+        }
+        val value = Value(data, Encoding(KnownEncoding.EMPTY))
+
+        val config = loadConfig()
+
+        Session.open(config).onSuccess {
+            it.use { session ->
+                session.declarePublisher("test/thr".intoKeyExpr().getOrThrow())
+                    .congestionControl(CongestionControl.BLOCK).apply {
+                        priorityInput?.let { priority(Priority.entries[it]) }
+                    }.res().onSuccess { pub ->
+                        pub.use {
+                            println("Publisher declared on test/thr.")
+                            var count: Long = 0
+                            var start = System.currentTimeMillis()
+                            val number = number.toLong()
+                            while (true) {
+                                pub.put(value).res().getOrThrow()
+
+                                if (statsPrint) {
+                                    if (count < number) {
+                                        count++
+                                    } else {
+                                        val throughput = count * 1000 / (System.currentTimeMillis() - start)
+                                        println("$throughput msgs/s")
+                                        count = 0
+                                        start = System.currentTimeMillis()
+                                    }
+                                }
+
+                            }
                         }
                     }
-                }
+            }
         }
     }
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
 }
+
+fun main(args: Array<String>) = ZPubThr(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -84,7 +84,7 @@ class ZPut(private val emptyArgs: Boolean) : CliktCommand(
                     }
                 }
             }
-        }
+        }.onFailure { println(it.message) }
     }
 
     private fun loadConfig(): Config {

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
 import io.zenoh.publication.CongestionControl
@@ -32,12 +29,12 @@ class ZPut(private val emptyArgs: Boolean) : CliktCommand(
     private val key by option(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"
     ).default("demo/example/zenoh-kotlin-put")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val mode by option(
         "-m",
         "--mode",

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -14,27 +14,99 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
 import io.zenoh.publication.CongestionControl
 import io.zenoh.publication.Priority
+import io.zenoh.sample.Attachment
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
 
-fun main() {
-    println("Opening Session")
-    Session.open().onSuccess { session ->
-        session.use {
-            val keyExpressionResult = "demo/example/zenoh-kotlin-put".intoKeyExpr()
-            keyExpressionResult.onSuccess { keyExpr ->
-                keyExpr.use {
-                    val value = "Put from Kotlin!"
-                    session.put(keyExpr, value)
-                        .congestionControl(CongestionControl.BLOCK)
-                        .priority(Priority.REALTIME)
-                        .kind(SampleKind.PUT)
-                        .res()
-                        .onSuccess { println("Putting Data ('$keyExpr': '$value')...") }
+class ZPut(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Put example"
+) {
+
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val key by option(
+        "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"
+    ).default("demo/example/zenoh-kotlin-put")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val value by option(
+        "-v", "--value", help = "The value to write. [Default: \"Put from Kotlin!\"]", metavar = "value"
+    ).default("Put from Kotlin!")
+    private val attachment by option(
+        "-a",
+        "--attach",
+        help = "The attachment to add to the put. The key-value pairs are &-separated, and = serves as the separator between key and value.",
+        metavar = "attach"
+    )
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+        val config = loadConfig()
+
+        println("Opening Session...")
+        Session.open(config).onSuccess { session ->
+            session.use {
+                key.intoKeyExpr().onSuccess { keyExpr ->
+                    keyExpr.use {
+                        session.put(keyExpr, value)
+                            .congestionControl(CongestionControl.BLOCK)
+                            .priority(Priority.REALTIME)
+                            .kind(SampleKind.PUT)
+                            .apply {
+                                attachment?.let {
+                                    withAttachment(decodeAttachment(it))
+                                }
+                            }
+                            .res()
+                            .onSuccess { println("Putting Data ('$keyExpr': '$value')...") }
+                    }
                 }
             }
         }
     }
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
+
+    private fun decodeAttachment(attachment: String): Attachment {
+        val pairs = attachment.split("&").map { it.split("=").let { (k, v) -> k.toByteArray() to v.toByteArray() } }
+        return Attachment.Builder().addAll(pairs).res()
+    }
 }
+
+fun main(args: Array<String>) = ZPut(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -19,7 +19,6 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
 import io.zenoh.publication.CongestionControl

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -17,31 +17,27 @@ package io.zenoh
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.varargValues
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
 import io.zenoh.publication.CongestionControl
 import io.zenoh.publication.Priority
-import io.zenoh.sample.Attachment
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlin.io.path.Path
 
 class ZPut(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Put example"
 ) {
 
-    private val connect: List<String> by option(
-        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).multiple()
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
     private val key by option(
         "-k", "--key", help = "The key expression to write to [default: demo/example/zenoh-kotlin-put]", metavar = "key"
     ).default("demo/example/zenoh-kotlin-put")
-    private val listen: List<String> by option(
+    private val connect: List<String>? by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).varargValues()
+    private val listen: List<String>? by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).multiple()
+    ).varargValues()
     private val mode by option(
         "-m",
         "--mode",
@@ -62,7 +58,7 @@ class ZPut(private val emptyArgs: Boolean) : CliktCommand(
     ).flag(default = false)
 
     override fun run() {
-        val config = loadConfig()
+        val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting,mode)
 
         println("Opening Session...")
         Session.open(config).onSuccess { session ->
@@ -84,27 +80,6 @@ class ZPut(private val emptyArgs: Boolean) : CliktCommand(
                 }
             }
         }.onFailure { println(it.message) }
-    }
-
-    private fun loadConfig(): Config {
-        val config = if (emptyArgs) {
-            Config.default()
-        } else {
-            configFile?.let { Config.from(Path(it)) } ?: let {
-                val connect = if (connect.isEmpty()) null else Connect(connect)
-                val listen = if (listen.isEmpty()) null else Listen(listen)
-                val scouting = Scouting(Multicast(!noMulticastScouting))
-                val configData = ConfigData(connect, listen, mode, scouting)
-                val jsonConfig = Json.encodeToJsonElement(configData)
-                Config.from(jsonConfig)
-            }
-        }
-        return config
-    }
-
-    private fun decodeAttachment(attachment: String): Attachment {
-        val pairs = attachment.split("&").map { it.split("=").let { (k, v) -> k.toByteArray() to v.toByteArray() } }
-        return Attachment.Builder().addAll(pairs).res()
     }
 }
 

--- a/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
@@ -47,12 +44,12 @@ class ZQueryable(private val emptyArgs: Boolean) : CliktCommand(
         help = "The session mode. Default: peer. Possible values: [peer, client, router]",
         metavar = "mode"
     ).default("peer")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val noMulticastScouting: Boolean by option(
         "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
     ).flag(default = false)

--- a/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQueryable.kt
@@ -14,25 +14,66 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.prelude.SampleKind
 import io.zenoh.queryable.Query
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
 import org.apache.commons.net.ntp.TimeStamp
+import kotlin.io.path.Path
 
-fun main() {
-    Session.open().onSuccess { session ->
-        session.use {
-            "demo/example/zenoh-kotlin-queryable".intoKeyExpr().onSuccess { keyExpr ->
-                keyExpr.use {
-                    println("Declaring Queryable")
-                    session.declareQueryable(keyExpr).res().onSuccess { queryable ->
-                        queryable.use {
-                            queryable.receiver?.let { receiverChannel -> //  The default receiver is a Channel we can process on a coroutine.
-                                runBlocking {
-                                    handleRequests(receiverChannel, keyExpr)
+class ZQueryable(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Queryable example"
+) {
+
+    private val key by option(
+        "-k",
+        "--key",
+        help = "The key expression to write to [default: demo/example/zenoh-kotlin-queryable]",
+        metavar = "key"
+    ).default("demo/example/zenoh-kotlin-queryable")
+    private val value by option(
+        "-v", "--value", help = "The value to reply to queries [default: \"Queryable from Kotlin!\"]", metavar = "value"
+    ).default("Queryable from Kotlin!")
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+        val config = loadConfig()
+
+        Session.open(config).onSuccess { session ->
+            session.use {
+                key.intoKeyExpr().onSuccess { keyExpr ->
+                    keyExpr.use {
+                        println("Declaring Queryable")
+                        session.declareQueryable(keyExpr).res().onSuccess { queryable ->
+                            queryable.use {
+                                queryable.receiver?.let { receiverChannel -> //  The default receiver is a Channel we can process on a coroutine.
+                                    runBlocking {
+                                        handleRequests(receiverChannel, keyExpr)
+                                    }
                                 }
                             }
                         }
@@ -41,19 +82,36 @@ fun main() {
             }
         }
     }
-}
 
-private suspend fun handleRequests(
-    receiverChannel: Channel<Query>, keyExpr: KeyExpr
-) {
-    val iterator = receiverChannel.iterator()
-    while (iterator.hasNext()) {
-        iterator.next().use { query ->
-            val valueInfo = query.value?.let { value -> " with value '$value'" } ?: ""
-            println(">> [Queryable] Received Query '${query.selector}' $valueInfo")
-            query.reply(keyExpr).success("Queryable from Kotlin!").withKind(SampleKind.PUT)
-                .withTimeStamp(TimeStamp.getCurrentTime()).res()
-                .onFailure { println(">> [Queryable ] Error sending reply: $it") }
+    private suspend fun handleRequests(
+        receiverChannel: Channel<Query>, keyExpr: KeyExpr
+    ) {
+        val iterator = receiverChannel.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().use { query ->
+                val valueInfo = query.value?.let { value -> " with value '$value'" } ?: ""
+                println(">> [Queryable] Received Query '${query.selector}' $valueInfo")
+                query.reply(keyExpr).success(value).withKind(SampleKind.PUT).withTimeStamp(TimeStamp.getCurrentTime())
+                    .res().onFailure { println(">> [Queryable ] Error sending reply: $it") }
+            }
         }
     }
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
 }
+
+fun main(args: Array<String>) = ZQueryable(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import kotlin.io.path.Path
 
-class ZSub(private val defaultConfig: Boolean) : CliktCommand(
+class ZSub(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Sub example"
 ) {
 
@@ -80,7 +80,7 @@ class ZSub(private val defaultConfig: Boolean) : CliktCommand(
     }
 
     private fun loadConfig(): Config {
-        val config = if (defaultConfig) {
+        val config = if (emptyArgs) {
             Config.default()
         } else {
             configFile?.let { Config.from(Path(it)) } ?: let {

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -16,7 +16,6 @@ package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.*
-import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -14,31 +14,82 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.*
+import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import kotlin.io.path.Path
 
-fun main() {
-    println("Opening session...")
-    Session.open().onSuccess { session ->
-        session.use {
-            "demo/example/**".intoKeyExpr().onSuccess { keyExpr ->
-                keyExpr.use {
-                    println("Declaring Subscriber on '$keyExpr'...")
-                    session.declareSubscriber(keyExpr).bestEffort().res().onSuccess { subscriber ->
-                        subscriber.use {
-                            runBlocking {
-                                val receiver = subscriber.receiver!!
-                                val iterator = receiver.iterator()
-                                while (iterator.hasNext()) {
-                                    val sample = iterator.next()
-                                    println(">> [Subscriber] Received ${sample.kind} ('${sample.keyExpr}': '${sample.value}')")
+class ZSub(private val defaultConfig: Boolean) : CliktCommand(
+    help = "Zenoh Sub example"
+) {
+
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val key by option(
+        "-k", "--key", help = "The key expression to subscribe to [default: demo/example/**]", metavar = "key"
+    ).default("demo/example/**")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    override fun run() {
+
+        val config = loadConfig()
+
+        println("Opening session...")
+        Session.open(config).onSuccess { session ->
+            session.use {
+                key.intoKeyExpr().onSuccess { keyExpr ->
+                    keyExpr.use {
+                        println("Declaring Subscriber on '$keyExpr'...")
+                        session.declareSubscriber(keyExpr).bestEffort().res().onSuccess { subscriber ->
+                            subscriber.use {
+                                runBlocking {
+                                    val receiver = subscriber.receiver!!
+                                    val iterator = receiver.iterator()
+                                    while (iterator.hasNext()) {
+                                        val sample = iterator.next()
+                                        println(">> [Subscriber] Received ${sample.kind} ('${sample.keyExpr}': '${sample.value}')")
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+        }.onFailure { exception -> println(exception.message) }
+    }
+
+    private fun loadConfig(): Config {
+        val config = if (defaultConfig) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
         }
+        return config
     }
 }
+
+fun main(args: Array<String>) = ZSub(args.isEmpty()).main(args)
 

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import io.zenoh.keyexpr.intoKeyExpr
 import kotlinx.coroutines.runBlocking
 
@@ -30,12 +27,12 @@ class ZSub(private val emptyArgs: Boolean) : CliktCommand(
     private val key by option(
         "-k", "--key", help = "The key expression to subscribe to [default: demo/example/**]", metavar = "key"
     ).default("demo/example/**")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val mode by option(
         "-m",
         "--mode",

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -47,7 +47,6 @@ class ZSub(private val defaultConfig: Boolean) : CliktCommand(
     ).flag(default = false)
 
     override fun run() {
-
         val config = loadConfig()
 
         println("Opening session...")
@@ -63,7 +62,13 @@ class ZSub(private val defaultConfig: Boolean) : CliktCommand(
                                     val iterator = receiver.iterator()
                                     while (iterator.hasNext()) {
                                         val sample = iterator.next()
-                                        println(">> [Subscriber] Received ${sample.kind} ('${sample.keyExpr}': '${sample.value}')")
+                                        println(">> [Subscriber] Received ${sample.kind} ('${sample.keyExpr}': '${sample.value}'" + "${
+                                            sample.attachment?.let {
+                                                ", with attachment: " + "${
+                                                    it.values.map { it.first.decodeToString() to it.second.decodeToString() }
+                                                }"
+                                            } ?: ""
+                                        })")
                                     }
                                 }
                             }

--- a/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
@@ -20,7 +20,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.ulong
-import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.subscriber.Subscriber
 import kotlinx.serialization.json.Json

--- a/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
@@ -14,58 +14,128 @@
 
 package io.zenoh
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.ulong
+import io.zenoh.config.*
 import io.zenoh.keyexpr.intoKeyExpr
+import io.zenoh.subscriber.Subscriber
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.io.path.Path
+import kotlin.system.exitProcess
 
-const val NANOS_TO_SEC = 1_000_000_000L
-var n = 50000L
-var batchCount = 0
-var count = 0
-var startTimestampNs: Long = 0
-var globalStartTimestampNs: Long = 0
+class ZSubThr(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Subscriber Throughput test"
+) {
 
-fun listener() {
-    if (count == 0) {
-        startTimestampNs = System.nanoTime()
-        if (globalStartTimestampNs == 0L) {
-            globalStartTimestampNs = startTimestampNs
+    private val samples by option(
+        "-s", "--samples", help = "Number of throughput measurements [default: 10]", metavar = "number"
+    ).ulong().default(10u)
+    private val number by option(
+        "-n",
+        "--number",
+        help = "Number of messages in each throughput measurements [default: 100000]",
+        metavar = "number"
+    ).ulong().default(10000u)
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+
+    companion object {
+        private const val NANOS_TO_SEC = 1_000_000_000L
+    }
+
+    private var batchCount = 0u
+    private var count = 0u
+    private var startTimestampNs: Long = 0
+    private var globalStartTimestampNs: Long = 0
+
+    private fun listener(number: ULong) {
+        if (batchCount > samples) {
+            subscriber.close()
+            report()
         }
-        count++
-        return
+        if (count == 0u) {
+            startTimestampNs = System.nanoTime()
+            if (globalStartTimestampNs == 0L) {
+                globalStartTimestampNs = startTimestampNs
+            }
+            count++
+            return
+        }
+        if (count < number) {
+            count++
+            return
+        }
+        val stop = System.nanoTime()
+        val elapsedTimeSecs = (stop - startTimestampNs).toDouble() / NANOS_TO_SEC
+        val messagesPerSec = number.toLong() / elapsedTimeSecs
+        println("$messagesPerSec msgs/sec")
+        batchCount++
+        count = 0u
     }
-    if (count < n) {
-        count++
-        return
+
+    private fun report() {
+        val end = System.nanoTime()
+        val total = batchCount * number + count
+        val elapsedTimeSecs = (end - globalStartTimestampNs).toDouble() / NANOS_TO_SEC
+        val globalMessagesPerSec = total.toLong() / elapsedTimeSecs
+        print("Received $total messages in $elapsedTimeSecs seconds: averaged $globalMessagesPerSec msgs/sec")
+        exitProcess(0)
     }
-    val stop = System.nanoTime()
-    val msgs = n * NANOS_TO_SEC / (stop - startTimestampNs)
-    println("$msgs msgs/sec")
-    batchCount++
-    count = 0
-}
 
-fun report() {
-    val end = System.nanoTime()
-    val total = batchCount * n + count
-    val msgs = (end - globalStartTimestampNs) / NANOS_TO_SEC
-    val avg = total * NANOS_TO_SEC / (end - globalStartTimestampNs)
-    print("Received $total messages in $msgs: averaged $avg msgs/sec")
-}
+    lateinit var subscriber: Subscriber<Unit>
+    override fun run() {
+        val config = loadConfig()
 
-fun main() {
-    "test/thr".intoKeyExpr().onSuccess {
-        it.use { keyExpr ->
-            println("Opening Session")
-            Session.open().onSuccess { it.use {
-                session -> session.declareSubscriber(keyExpr)
-                    .reliable()
-                    .with { listener() }
-                    .res()
-                    .onSuccess {
-                        while (readlnOrNull() != "q") { /* Do nothing */ }
+        "test/thr".intoKeyExpr().onSuccess {
+            it.use { keyExpr ->
+                println("Opening Session")
+                Session.open(config).onSuccess {
+                    it.use { session ->
+                        subscriber =
+                            session.declareSubscriber(keyExpr).reliable().with { listener(number) }.res().getOrThrow()
+                        while (subscriber.isValid()) {
+                            /* Keep alive the subscriber until the test is done. */
+                        }
                     }
                 }
             }
         }
     }
-    report()
+
+    private fun loadConfig(): Config {
+        val config = if (emptyArgs) {
+            Config.default()
+        } else {
+            configFile?.let { Config.from(Path(it)) } ?: let {
+                val connect = if (connect.isEmpty()) null else Connect(connect)
+                val listen = if (listen.isEmpty()) null else Listen(listen)
+                val scouting = Scouting(Multicast(!noMulticastScouting))
+                val configData = ConfigData(connect, listen, mode, scouting)
+                val jsonConfig = Json.encodeToJsonElement(configData)
+                Config.from(jsonConfig)
+            }
+        }
+        return config
+    }
 }
+
+fun main(args: Array<String>) = ZSubThr(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
@@ -15,10 +15,7 @@
 package io.zenoh
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.varargValues
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.ulong
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.subscriber.Subscriber
@@ -38,12 +35,12 @@ class ZSubThr(private val emptyArgs: Boolean) : CliktCommand(
         metavar = "number"
     ).ulong().default(10000u)
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
-    private val connect: List<String>? by option(
+    private val connect: List<String> by option(
         "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
-    ).varargValues()
-    private val listen: List<String>? by option(
+    ).multiple()
+    private val listen: List<String> by option(
         "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
-    ).varargValues()
+    ).multiple()
     private val mode by option(
         "-m",
         "--mode",

--- a/examples/src/main/kotlin/io/zenoh/config/Config.kt
+++ b/examples/src/main/kotlin/io/zenoh/config/Config.kt
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.config
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+data class ConfigData(
+    @SerialName("connect")
+    var connect: Connect? = null,
+    @SerialName("listen")
+    var listen: Listen? = null,
+    @SerialName("mode")
+    var mode: String? = null,
+    @SerialName("scouting")
+    var scouting: Scouting? = null,
+)
+
+@Serializable
+data class Connect(
+    @SerialName("endpoints")
+    var endpoints: List<String>
+)
+
+@Serializable
+data class Listen(
+    @SerialName("endpoints")
+    var endpoints: List<String>
+)
+
+@Serializable
+data class Scouting(
+    @SerialName("multicast")
+    var multicast: Multicast,
+)
+
+@Serializable
+data class Multicast(
+    @SerialName("enabled")
+    var enabled: Boolean,
+)

--- a/zenoh-jni/Cargo.lock
+++ b/zenoh-jni/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -62,38 +62,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fe8042a3174caeafdad8ee1337788db51833e7f8649c07c6d6de70048adef4"
 dependencies = [
  "bytes",
- "env_logger",
+ "env_logger 0.10.2",
  "lazy_static",
  "libc",
  "log",
  "parking_lot",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "thiserror",
  "time",
  "winapi",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
+name = "anstream"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "async-channel"
@@ -107,31 +145,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.5.1"
+name = "async-channel"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
- "async-lock",
+ "concurrent-queue",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
- "fastrand",
- "futures-lite",
+ "fastrand 2.0.1",
+ "futures-lite 2.3.0",
  "slab",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel",
+ "async-channel 2.2.0",
  "async-executor",
- "async-io",
- "async-lock",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
  "blocking",
- "futures-lite",
+ "futures-lite 2.3.0",
  "once_cell",
  "tokio",
 ]
@@ -142,18 +193,37 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "autocfg",
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
  "parking",
- "polling",
- "rustix 0.37.25",
+ "polling 2.8.0",
+ "rustix 0.37.27",
  "slab",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "parking",
+ "polling 3.5.0",
+ "rustix 0.38.32",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -166,31 +236,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "1.7.0"
+name = "async-lock"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "async-io",
- "async-lock",
- "autocfg",
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
  "blocking",
  "cfg-if",
- "event-listener 2.5.3",
- "futures-lite",
- "rustix 0.37.25",
- "signal-hook",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.32",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "async-rustls"
-version = "0.4.0"
+name = "async-signal"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29479d362e242e320fa8f5c831940a5b83c1679af014068196cd20d4bf497b6b"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
+ "async-io 2.3.2",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
  "futures-io",
- "rustls",
+ "rustix 0.38.32",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -199,17 +287,16 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
- "async-attributes",
- "async-channel",
+ "async-channel 1.9.0",
  "async-global-executor",
- "async-io",
- "async-lock",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite",
+ "futures-lite 1.13.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -223,26 +310,26 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.4.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -278,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -305,9 +392,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -320,30 +407,31 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel",
- "async-lock",
+ "async-channel 2.2.0",
+ "async-lock 3.3.0",
  "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "log",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -359,12 +447,9 @@ checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cesu8"
@@ -413,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,33 +515,33 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -459,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -469,27 +560,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -503,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der"
@@ -520,9 +608,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -559,21 +650,44 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -584,23 +698,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -611,12 +714,54 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
  "pin-project-lite",
 ]
 
@@ -628,6 +773,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fixedbitset"
@@ -668,18 +819,18 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -692,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -702,15 +853,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -719,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -729,7 +880,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -739,33 +890,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
+name = "futures-lite"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -791,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -804,30 +968,28 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-version"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
 dependencies = [
  "git-version-macro",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "git-version-macro"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -859,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -878,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hmac"
@@ -893,18 +1055,18 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -925,9 +1087,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -945,12 +1107,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -977,7 +1139,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -993,20 +1155,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.13",
- "windows-sys 0.48.0",
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jni"
@@ -1032,9 +1194,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1052,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -1088,25 +1250,36 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1116,15 +1289,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1132,42 +1305,42 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1189,7 +1362,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.5.0",
  "cfg-if",
  "libc",
 ]
@@ -1218,20 +1391,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1240,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -1254,24 +1432,24 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -1287,9 +1465,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -1302,9 +1480,9 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -1318,13 +1496,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -1346,15 +1524,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.3"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1363,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.3"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1373,22 +1551,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.3"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.3"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -1402,27 +1580,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1436,6 +1614,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs1"
@@ -1507,22 +1696,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.32",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1538,7 +1741,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -1546,15 +1749,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
+checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
  "rand",
  "ring 0.16.20",
  "rustc-hash",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs 0.6.3",
  "slab",
  "thiserror",
@@ -1570,16 +1773,16 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tracing",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1616,24 +1819,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -1643,20 +1828,20 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1666,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1677,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
@@ -1698,16 +1883,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.6"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1722,16 +1908,14 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
- "byteorder",
  "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
@@ -1765,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.25"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1779,27 +1963,41 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.13",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.16.20",
- "rustls-webpki 0.101.5",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1809,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.3",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -1821,7 +2019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.0.0",
+ "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -1829,18 +2027,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -1848,36 +2046,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
- "ring 0.17.6",
+ "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -1890,18 +2088,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "schemars"
-version = "0.8.13"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -1911,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.13"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1929,12 +2127,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1972,28 +2170,28 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2009,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -2020,11 +2218,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -2033,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2044,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2073,16 +2271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -2112,15 +2300,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -2128,12 +2316,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2153,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -2173,7 +2361,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "cfg-if",
  "futures-core",
  "pin-project-lite",
@@ -2204,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.33"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2215,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -2230,32 +2418,34 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2263,16 +2453,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -2302,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2312,27 +2503,48 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
@@ -2341,12 +2553,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.37"
+name = "tokio-util"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "cfg-if",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.3",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2355,29 +2581,29 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2404,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -2430,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -2442,9 +2668,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -2457,9 +2683,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2486,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2502,10 +2728,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "uuid"
-version = "1.4.1"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
 ]
@@ -2536,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
 
 [[package]]
 name = "vec_map"
@@ -2554,15 +2786,15 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2576,9 +2808,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2586,24 +2818,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2613,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2623,28 +2855,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2652,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2677,9 +2909,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -2706,6 +2938,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2739,6 +2980,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +3005,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2763,6 +3025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +3041,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2787,6 +3061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +3077,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2811,6 +3097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,17 +3115,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-global-executor",
- "async-std",
  "async-trait",
  "base64",
  "const_format",
- "env_logger",
- "event-listener 4.0.0",
+ "env_logger 0.11.3",
+ "event-listener 4.0.3",
  "flume 0.11.0",
  "form_urlencoded",
  "futures",
@@ -2848,8 +3144,10 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "stop-token",
+ "tokio",
+ "tokio-util",
  "uhlc",
  "uuid",
  "vec_map",
@@ -2865,6 +3163,7 @@ dependencies = [
  "zenoh-plugin-trait",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-transport",
  "zenoh-util",
@@ -2873,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2881,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "log",
  "serde",
@@ -2893,15 +3192,16 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "flume 0.11.0",
  "json5",
+ "log",
  "num_cpus",
  "secrecy",
  "serde",
@@ -2917,17 +3217,19 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
+ "async-global-executor",
  "lazy_static",
+ "tokio",
  "zenoh-result",
+ "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "aes",
  "hmac",
@@ -2940,19 +3242,20 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "bincode",
- "env_logger",
+ "env_logger 0.11.3",
  "flume 0.11.0",
  "futures",
  "log",
  "serde",
+ "tokio",
  "zenoh",
  "zenoh-core",
  "zenoh-macros",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -2960,9 +3263,9 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "keyed-set",
  "rand",
  "schemars",
@@ -2974,9 +3277,8 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "zenoh-config",
  "zenoh-link-commons",
@@ -2993,43 +3295,50 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "flume 0.11.0",
+ "futures",
  "log",
+ "rustls 0.22.2",
+ "rustls-webpki 0.102.2",
  "serde",
+ "tokio",
+ "tokio-util",
  "zenoh-buffers",
  "zenoh-codec",
  "zenoh-core",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-sync",
+ "zenoh-runtime",
  "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-rustls",
- "async-std",
  "async-trait",
  "base64",
  "futures",
  "log",
  "quinn",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs 0.7.0",
- "rustls-pemfile 2.0.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
  "secrecy",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
  "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3037,15 +3346,17 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "log",
+ "tokio",
+ "tokio-util",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3053,24 +3364,27 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-rustls",
- "async-std",
  "async-trait",
  "base64",
  "futures",
  "log",
- "rustls",
- "rustls-pemfile 2.0.0",
- "rustls-webpki 0.102.0",
+ "rustls 0.22.2",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
  "secrecy",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-util",
  "webpki-roots",
  "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3078,18 +3392,20 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "log",
- "socket2 0.5.4",
+ "socket2 0.5.6",
+ "tokio",
+ "tokio-util",
  "zenoh-buffers",
  "zenoh-collections",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3097,37 +3413,40 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "futures",
  "log",
  "nix",
+ "tokio",
+ "tokio-util",
  "uuid",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
 ]
 
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
  "async-trait",
  "futures-util",
  "log",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "url",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3135,18 +3454,18 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
  "zenoh-keyexpr",
 ]
 
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "const_format",
  "libloading",
@@ -3162,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "const_format",
  "rand",
@@ -3176,33 +3495,41 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
+name = "zenoh-runtime"
+version = "0.11.0-dev"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
+dependencies = [
+ "lazy_static",
+ "tokio",
+ "zenoh-collections",
+ "zenoh-result",
+]
+
+[[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-std",
- "event-listener 4.0.0",
+ "event-listener 4.0.3",
  "futures",
  "tokio",
  "zenoh-buffers",
  "zenoh-collections",
  "zenoh-core",
+ "zenoh-runtime",
 ]
 
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
- "async-executor",
- "async-global-executor",
- "async-std",
  "async-trait",
  "flume 0.11.0",
  "log",
@@ -3213,6 +3540,8 @@ dependencies = [
  "rsa",
  "serde",
  "sha3",
+ "tokio",
+ "tokio-util",
  "zenoh-buffers",
  "zenoh-codec",
  "zenoh-collections",
@@ -3222,6 +3551,7 @@ dependencies = [
  "zenoh-link",
  "zenoh-protocol",
  "zenoh-result",
+ "zenoh-runtime",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3229,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#4537dc26553397a4865953e46cacd6ed2ba5cfb6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1d1df0eeec3b897079a9aa5f8441c7fddb83d196"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3242,6 +3572,7 @@ dependencies = [
  "log",
  "pnet_datalink",
  "shellexpand",
+ "tokio",
  "winapi",
  "zenoh-core",
  "zenoh-result",
@@ -3254,7 +3585,7 @@ dependencies = [
  "android-logd-logger",
  "async-std",
  "clap",
- "env_logger",
+ "env_logger 0.10.2",
  "flume 0.10.14",
  "jni",
  "json5",
@@ -3282,11 +3613,11 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -22,19 +22,17 @@ use jni::{
 use zenoh::{
     prelude::{sync::SyncResolve, KeyExpr},
     publication::Publisher,
-    Session,
+    Session, SessionDeclarations,
 };
 
 use crate::{
     errors::{Error, Result},
-    sample::decode_sample_kind,
     utils::{decode_byte_array, vec_to_attachment},
 };
 use crate::{
     put::{decode_congestion_control, decode_priority},
     value::decode_value,
 };
-use zenoh::SessionDeclarations;
 
 /// Performs a put operation on a Zenoh publisher via JNI.
 ///
@@ -264,92 +262,6 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_setPriorityViaJNI(
         let publisher = core::ptr::read(ptr);
         core::ptr::write(ptr as *mut _, publisher.priority(priority));
     }
-}
-
-/// Performs a WRITE operation via JNI using the specified Zenoh publisher.
-///
-/// Parameters:
-/// - `env`: The JNI environment.
-/// - `payload`: The payload as a `JByteArray`.
-/// - `encoding`: The [zenoh::Encoding] of the payload.
-/// - `sample_kind`: The [zenoh::SampleKind] to use.
-/// - `encoded_attachment`: Optional encoded attachment. May be null.
-/// - `publisher`: The Zenoh [Publisher].
-///
-/// Returns:
-/// - A [Result] indicating the success or failure of the operation.
-///
-fn perform_write(
-    env: &JNIEnv,
-    payload: JByteArray,
-    encoding: jint,
-    sample_kind: jint,
-    encoded_attachment: JByteArray,
-    publisher: Arc<Publisher>,
-) -> Result<()> {
-    let value = decode_value(env, payload, encoding)?;
-    let sample_kind = decode_sample_kind(sample_kind)?;
-    let mut publication = publisher.write(sample_kind, value);
-    if !encoded_attachment.is_null() {
-        let aux = decode_byte_array(env, encoded_attachment)?;
-        publication = publication.with_attachment(vec_to_attachment(aux))
-    };
-    publication
-        .res()
-        .map_err(|err| Error::Session(format!("{}", err)))
-}
-
-/// Performs a WRITE operation on a Zenoh publisher via JNI.
-///
-/// This function is meant to be called from Java/Kotlin code through JNI.
-///
-/// Parameters:
-/// - `env`: The JNI environment.
-/// - `_class`: The JNI class.
-/// - `payload`: The payload to be published, represented as a [Java byte array](JByteArray).
-/// - `encoding`: The [`encoding`](zenoh::Encoding) of the payload.
-/// - `sample_kind`: The [`kind`](zenoh::SampleKind) to use.
-/// - `encoded_attachment`: Optional encoded attachment. May be null.
-/// - `ptr`: The raw pointer to the Zenoh publisher ([Publisher]).
-///
-/// Safety:
-/// - The function is marked as unsafe due to raw pointer manipulation and JNI interaction.
-/// - It assumes that the provided publisher pointer is valid and has not been modified or freed.
-/// - The ownership of the publisher is not transferred, and it is safe to continue using the publisher
-///   after this function call.
-/// - The function may throw an exception in case of failure, which should be handled by the caller.
-///
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_writeViaJNI(
-    mut env: JNIEnv,
-    _class: JClass,
-    payload: JByteArray,
-    encoding: jint,
-    sample_kind: jint,
-    encoded_attachment: JByteArray,
-    ptr: *const Publisher<'static>,
-) {
-    let publisher = Arc::from_raw(ptr);
-    match perform_write(
-        &env,
-        payload,
-        encoding,
-        sample_kind,
-        encoded_attachment,
-        publisher.clone(),
-    ) {
-        Ok(_) => {}
-        Err(err) => {
-            _ = err.throw_on_jvm(&mut env).map_err(|err| {
-                log::error!(
-                    "Unable to throw exception on WRITE operation failure: {}",
-                    err
-                )
-            });
-        }
-    };
-    std::mem::forget(publisher)
 }
 
 /// Performs a DELETE operation via JNI using the specified Zenoh publisher.

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -12,8 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use zenoh::publication::HasWriteWithSampleKind;
 use std::{ops::Deref, sync::Arc};
+use zenoh::publication::HasWriteWithSampleKind;
 
 use jni::{
     objects::{JByteArray, JClass},

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use zenoh::publication::HasWriteWithSampleKind;
 use std::{ops::Deref, sync::Arc};
 
 use jni::{
@@ -195,7 +196,7 @@ fn perform_put(
 /// - This function is maked as unsafe due to raw pointer manipulation.
 /// - This function is NOT thread safe; if there were to be multiple threads calling this function
 ///   concurrently while providing the same Publisher pointer, the result will be non deterministic.
-///  
+///
 /// Throws:
 /// - An exception in case the congestion control fails to be decoded.
 ///
@@ -238,7 +239,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_setCongestionControlViaJ
 /// - This function is maked as unsafe due to raw pointer manipulation.
 /// - This function is NOT thread safe; if there were to be multiple threads calling this function
 ///   concurrently while providing the same Publisher pointer, the result will be non deterministic.
-///  
+///
 /// Throws:
 /// - An exception in case the priority fails to be decoded.
 ///

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -13,7 +13,6 @@
 //
 
 use std::{ops::Deref, sync::Arc};
-use zenoh::publication::HasWriteWithSampleKind;
 
 use jni::{
     objects::{JByteArray, JClass},
@@ -321,7 +320,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_deleteViaJNI(
         Err(err) => {
             _ = err.throw_on_jvm(&mut env).map_err(|err| {
                 log::error!(
-                    "Unable to throw exception on WRITE operation failure: {}",
+                    "Unable to throw exception on DELETE operation failure: {}",
                     err
                 )
             });

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -58,12 +58,19 @@ class Config private constructor(internal val path: Path? = null, internal val j
         /**
          * Loads the configuration from the [json] specified.
          *
-         * @param json The zenoh raw zenoh config.
+         * @param json The raw zenoh config.
          */
         fun from(json: String): Config {
             return Config(jsonConfig = Json.decodeFromString(json))
         }
+
+        /**
+         * Loads the configuration from the [jsonElement] specified.
+         *
+         * @param jsonElement The zenoh config as a [JsonElement].
+         */
+        fun from(jsonElement: JsonElement) = Config(jsonElement)
     }
 
-    constructor(jsonConfig: JsonElement) : this(null, jsonConfig = jsonConfig)
+    private constructor(jsonConfig: JsonElement) : this(null, jsonConfig = jsonConfig)
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
@@ -15,7 +15,6 @@
 package io.zenoh.jni
 
 import io.zenoh.*
-import io.zenoh.prelude.SampleKind
 import io.zenoh.publication.CongestionControl
 import io.zenoh.publication.Priority
 import io.zenoh.sample.Attachment
@@ -36,23 +35,6 @@ internal class JNIPublisher(private val ptr: Long) {
      */
     fun put(value: Value, attachment: Attachment?): Result<Unit> = runCatching {
         putViaJNI(value.payload, value.encoding.knownEncoding.ordinal, attachment?.let { encodeAttachment(it) }, ptr)
-    }
-
-    /**
-     * Write operation.
-     *
-     * @param kind The [SampleKind].
-     * @param value The [Value]  to be written.
-     * @param attachment Optional [Attachment].
-     */
-    fun write(kind: SampleKind, value: Value, attachment: Attachment?): Result<Unit> = runCatching {
-        writeViaJNI(
-            value.payload,
-            value.encoding.knownEncoding.ordinal,
-            kind.ordinal,
-            attachment?.let { encodeAttachment(it) },
-            ptr
-        )
     }
 
     /**
@@ -122,11 +104,6 @@ internal class JNIPublisher(private val ptr: Long) {
     @Throws(Exception::class)
     private external fun putViaJNI(
         valuePayload: ByteArray, valueEncoding: Int, encodedAttachment: ByteArray?, ptr: Long
-    )
-
-    @Throws(Exception::class)
-    private external fun writeViaJNI(
-        payload: ByteArray, encoding: Int, sampleKind: Int, encodedAttachment: ByteArray?, ptr: Long
     )
 
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
@@ -18,7 +18,6 @@ import io.zenoh.*
 import io.zenoh.exceptions.SessionException
 import io.zenoh.jni.JNIPublisher
 import io.zenoh.keyexpr.KeyExpr
-import io.zenoh.prelude.SampleKind
 import io.zenoh.sample.Attachment
 import io.zenoh.value.Value
 
@@ -79,15 +78,6 @@ class Publisher internal constructor(
 
     /** Performs a PUT operation on the specified [keyExpr] with the specified string [value]. */
     fun put(value: String) = Put(jniPublisher, Value(value))
-
-    /**
-     * Performs a WRITE operation on the specified [keyExpr]
-     *
-     * @param kind The [SampleKind] of the data.
-     * @param value The [Value] to send.
-     * @return A [Resolvable] operation.
-     */
-    fun write(kind: SampleKind, value: Value) = Write(jniPublisher, value, kind)
 
     /**
      * Performs a DELETE operation on the specified [keyExpr]
@@ -155,20 +145,6 @@ class Publisher internal constructor(
 
         override fun res(): Result<Unit> = run {
             jniPublisher?.put(value, attachment) ?: InvalidPublisherResult
-        }
-    }
-
-    class Write internal constructor(
-        private var jniPublisher: JNIPublisher?,
-        val value: Value,
-        val sampleKind: SampleKind,
-        var attachment: Attachment? = null
-    ) : Resolvable<Unit> {
-
-        fun withAttachment(attachment: Attachment) = apply { this.attachment = attachment }
-
-        override fun res(): Result<Unit> = run {
-            jniPublisher?.write(sampleKind, value, attachment) ?: InvalidPublisherResult
         }
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/sample/Attachment.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/sample/Attachment.kt
@@ -45,11 +45,11 @@ class Attachment internal constructor(val values: List<Pair<ByteArray, ByteArray
             values.add(key.toByteArray() to value.toByteArray())
         }
 
-        fun addAll(elements: Collection<Pair<ByteArray, ByteArray>>) {
+        fun addAll(elements: Collection<Pair<ByteArray, ByteArray>>) = apply {
             values.addAll(elements)
         }
 
-        fun addAll(elements: Iterable<Pair<ByteArray, ByteArray>>) {
+        fun addAll(elements: Iterable<Pair<ByteArray, ByteArray>>) = apply {
             values.addAll(elements)
         }
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/PublisherTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/PublisherTest.kt
@@ -55,33 +55,6 @@ class PublisherTest {
     }
 
     @Test
-    fun writeTest() {
-        val session = Session.open().getOrThrow()
-        val receivedSamples = ArrayList<Sample>()
-        session.declareSubscriber(TEST_KEY_EXP).with { sample ->
-            receivedSamples.add(sample)
-        }.res()
-
-        val testSamples = arrayListOf(
-            Sample(TEST_KEY_EXP, Value("Test PUT"), SampleKind.PUT, null),
-            Sample(TEST_KEY_EXP, Value("Test DELETE"), SampleKind.DELETE, null),
-        )
-
-        session.declarePublisher(TEST_KEY_EXP).res().onSuccess {
-            it.use { publisher ->
-                publisher.write(testSamples[0].kind, testSamples[0].value).res()
-                publisher.write(testSamples[1].kind, testSamples[1].value).res()
-            }
-        }
-
-        session.close()
-        assertEquals(testSamples.size, receivedSamples.size)
-        for ((index, sample) in receivedSamples.withIndex()) {
-            assertEquals(sample, testSamples[index])
-        }
-    }
-
-    @Test
     fun deleteTest() {
         val session = Session.open().getOrThrow()
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
@@ -98,39 +98,6 @@ class UserAttachmentTest {
     }
 
     @Test
-    fun publisherWriteWithAttachmentTest() {
-        val session = Session.open().getOrThrow()
-
-        var receivedSample: Sample? = null
-        val publisher = session.declarePublisher(keyExpr).res().getOrThrow()
-        session.declareSubscriber(keyExpr).with { sample ->
-            receivedSample = sample
-        }.res()
-
-        publisher.write(SampleKind.PUT, Value("test")).withAttachment(attachment).res()
-        session.close()
-
-        assertAttachmentOk(receivedSample!!.attachment!!)
-    }
-
-    @Test
-    fun publisherWriteWithoutAttachmentTest() {
-        val session = Session.open().getOrThrow()
-
-        var receivedSample: Sample? = null
-        val publisher = session.declarePublisher(keyExpr).res().getOrThrow()
-        session.declareSubscriber(keyExpr).with { sample ->
-            receivedSample = sample
-        }.res()
-
-        publisher.write(SampleKind.PUT, Value("test")).res()
-        session.close()
-
-        assertNotNull(receivedSample)
-        assertNull(receivedSample!!.attachment)
-    }
-
-    @Test
     fun publisherDeleteWithAttachmentTest() {
         val session = Session.open().getOrThrow()
 


### PR DESCRIPTION
Using Clickt to allow users to specify arguments when running examples on Kotlin.

# Usage

For instance the ZPub example, you run it using gradle, and providing the arguments the following way:

```bash
gradle ZPub --args="<your arguments>"
```

** Example: **
```bash
gradle ZPub --args="-h"
```

will display the help menu with the available arguments:
```
> Task :examples:ZPub
Usage: zpub [<options>]

  Zenoh Pub example

Options:
  -e, --connect=<connect>  Endpoints to connect to.
  -c, --config=<config>    A configuration file.
  -k, --key=<key>          The key expression to write to [default:
                           demo/example/zenoh-kotlin-pub]
  -l, --listen=<listen>    Endpoints to listen on.
  -m, --mode=<mode>        The session mode. Default: peer. Possible values:
                           [peer, client, router]
  -v, --value=<value>      The value to write. [Default: "Pub from Kotlin!"]
  -a, --attach=<attach>    The attachments to add to each put. The key-value
                           pairs are &-separated, and = serves as the separator
                           between key and value.
  --no-multicast-scouting  Disable the multicast-based scouting mechanism.
  -h, --help               Show this message and exit
```




Solves #55 