### PR TITLE
Use for loop for kotlin Channels in examples

### DIFF
--- a/examples/src/main/kotlin/io.zenoh/ZGet.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZGet.kt
@@ -89,16 +89,12 @@ class ZGet(private val emptyArgs: Boolean) : CliktCommand(
                                 }
                             }
                             .res()
-                            .onSuccess {
+                            .onSuccess { receiver ->
                                 runBlocking {
-                                    val iterator = it!!.iterator()
-                                    while (iterator.hasNext()) {
-                                        val reply = iterator.next()
-                                        if (reply is Reply.Success) {
-                                            println("Received ('${reply.sample.keyExpr}': '${reply.sample.value}')")
-                                        } else {
-                                            reply as Reply.Error
-                                            println("Received (ERROR: '${reply.error}')")
+                                    for (reply in receiver!!) {
+                                        when (reply) {
+                                            is Reply.Success -> {println("Received ('${reply.sample.keyExpr}': '${reply.sample.value}')")}
+                                            is Reply.Error -> println("Received (ERROR: '${reply.error}')")
                                         }
                                     }
                                 }

--- a/examples/src/main/kotlin/io.zenoh/ZSub.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSub.kt
@@ -56,10 +56,7 @@ class ZSub(private val emptyArgs: Boolean) : CliktCommand(
                             subscriber.use {
                                 println("Press CTRL-C to quit...")
                                 runBlocking {
-                                    val receiver = subscriber.receiver!!
-                                    val iterator = receiver.iterator()
-                                    while (iterator.hasNext()) {
-                                        val sample = iterator.next()
+                                    for (sample in subscriber.receiver!!) {
                                         println(">> [Subscriber] Received ${sample.kind} ('${sample.keyExpr}': '${sample.value}'" + "${
                                             sample.attachment?.let {
                                                 ", with attachment: " + "${

--- a/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZSubThr.kt
@@ -99,11 +99,11 @@ class ZSubThr(private val emptyArgs: Boolean) : CliktCommand(
     override fun run() {
         val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting, mode)
 
-        "test/thr".intoKeyExpr().onSuccess {
-            it.use { keyExpr ->
+        "test/thr".intoKeyExpr().onSuccess { keyExpr ->
+            keyExpr.use {
                 println("Opening Session")
-                Session.open(config).onSuccess {
-                    it.use { session ->
+                Session.open(config).onSuccess { session ->
+                    session.use {
                         println("Press CTRL-C to quit...")
                         subscriber =
                             session.declareSubscriber(keyExpr).reliable().with { listener(number) }.res().getOrThrow()


### PR DESCRIPTION
For someone who's not familiar with Kotlin channels (like me before using them with this library) the current syntax of the examples might look too verbose. 
I think using the `for` loop makes it a bit easier to parse, and seems to be more idiomatic according to [Kotlin's docs](https://kotlinlang.org/docs/channels.html)

Other changes:
- Used `when` case for Get replies
- Changed the lambda paramters in `examples/src/main/kotlin/io.zenoh/ZSubThr.kt` to make it similar to other examples