### PR TITLE
fix: Unset `branch` input in publishing workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
     uses: ./.github/workflows/publish-jvm.yml
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
+      branch: ${{ needs.tag.outputs.branch }}
     permissions:
       contents: read
       packages: write
@@ -78,6 +79,7 @@ jobs:
     uses: ./.github/workflows/publish-android.yml
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
+      branch: ${{ needs.tag.outputs.branch }}
     permissions:
       contents: read
       packages: write
@@ -88,6 +90,7 @@ jobs:
     uses: ./.github/workflows/publish-dokka.yml
     with:
       live-run: ${{ inputs.live-run || false }}
+      branch: ${{ needs.tag.outputs.branch }}
 
   publish-github:
     needs: tag


### PR DESCRIPTION
[Publishing workflows (JVM, Android, Dokka) aren't passed the release branch input.](https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/8895450205)