### PR TITLE
Update rustc version and how cross is installed via cargo

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -78,7 +78,7 @@ jobs:
               ;;
           esac
 
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo +stable install cross --locked
 
       - name: Install Rust toolchain
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.72.0"


### PR DESCRIPTION
First change is to update how cross is installed via cargo. Add +stable option to cargo and install via crates.io instead of git. This way we have better control over the version of cross that will get installed.

Second change is to bump the rustc version to 1.72.0 to match the zenoh version.

