### PR TITLE
Modifying key expression handling

### DIFF
--- a/zenoh-jni/src/key_expr.rs
+++ b/zenoh-jni/src/key_expr.rs
@@ -96,22 +96,6 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_includesViaJNI(
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_equalsViaJNI(
-    _env: JNIEnv,
-    _: JClass,
-    key_expr_ptr_1: *const KeyExpr<'static>,
-    key_expr_ptr_2: *const KeyExpr<'static>,
-) -> jboolean {
-    let key_expr_1 = Arc::from_raw(key_expr_ptr_1);
-    let key_expr_2 = Arc::from_raw(key_expr_ptr_2);
-    let is_equal = key_expr_1.eq(&key_expr_2);
-    std::mem::forget(key_expr_1);
-    std::mem::forget(key_expr_2);
-    is_equal as jboolean
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,

--- a/zenoh-jni/src/key_expr.rs
+++ b/zenoh-jni/src/key_expr.rs
@@ -86,17 +86,23 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_inte
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_includesViaJNI(
-    _env: JNIEnv,
+pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_includesViaJNI(
+    mut env: JNIEnv,
     _: JClass,
     key_expr_ptr_1: *const KeyExpr<'static>,
+    key_expr_str_1: JString,
     key_expr_ptr_2: *const KeyExpr<'static>,
+    key_expr_str_2: JString,
 ) -> jboolean {
-    let key_expr_1 = Arc::from_raw(key_expr_ptr_1);
-    let key_expr_2 = Arc::from_raw(key_expr_ptr_2);
+    let key_expr_1 = match process_key_expr_or_throw(&mut env, &key_expr_str_1, key_expr_ptr_1) {
+        Ok(key_expr) => key_expr,
+        Err(_) => return false as jboolean,
+    };
+    let key_expr_2 = match process_key_expr_or_throw(&mut env, &key_expr_str_2, key_expr_ptr_2) {
+        Ok(key_expr) => key_expr,
+        Err(_) => return false as jboolean,
+    };
     let includes = key_expr_1.includes(&key_expr_2);
-    std::mem::forget(key_expr_1);
-    std::mem::forget(key_expr_2);
     includes as jboolean
 }
 

--- a/zenoh-jni/src/key_expr.rs
+++ b/zenoh-jni/src/key_expr.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use std::ops::Deref;
 use std::ptr::null;
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use jni::{objects::JString, JNIEnv};
 use zenoh::prelude::KeyExpr;
 
 use crate::errors::Error;
+use crate::errors::Result;
 use crate::utils::decode_string;
 
 #[no_mangle]
@@ -30,21 +32,56 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_tryF
     _class: JClass,
     key_expr: JString,
 ) -> *const KeyExpr<'static> {
-    let key_expr_str = match decode_string(&mut env, key_expr) {
-        Ok(key_expr) => key_expr,
+    match decode_key_expr(&mut env, &key_expr) {
+        Ok(key_expr) => Arc::into_raw(Arc::new(key_expr)),
         Err(err) => {
-            _ = err.throw_on_jvm(&mut env);
-            return null();
+            _ = Error::KeyExpr(err.to_string()).throw_on_jvm(&mut env);
+            null()
+        }
+    }
+}
+
+pub(crate) fn decode_key_expr(env: &mut JNIEnv, key_expr: &JString) -> Result<KeyExpr<'static>> {
+    let key_expr_str = match decode_string(env, key_expr) {
+        Ok(key_expr_str) => key_expr_str,
+        Err(err) => {
+            return Err(Error::Jni(format!(
+                "Unable to get key expression string value: {}",
+                err
+            )));
         }
     };
     let key_expr = match KeyExpr::try_from(key_expr_str) {
         Ok(key_expr) => key_expr,
         Err(err) => {
-            _ = Error::KeyExpr(err.to_string()).throw_on_jvm(&mut env);
-            return null();
+            return Err(Error::Jni(format!(
+                "Unable to create key expression from string: {}",
+                err
+            )));
         }
     };
-    Arc::into_raw(Arc::new(key_expr))
+    Ok(key_expr)
+}
+
+pub(crate) unsafe fn process_key_expr(
+    env: &mut JNIEnv,
+    key_expr_str: &JString,
+    key_expr_ptr: *const KeyExpr<'static>,
+) -> Result<KeyExpr<'static>> {
+    if key_expr_ptr.is_null() {
+        match decode_key_expr(env, key_expr_str) {
+            Ok(key_expr) => Ok(key_expr),
+            Err(err) => Err(Error::Jni(format!(
+                "Unable to process key expression: {}",
+                err
+            ))),
+        }
+    } else {
+        let key_expr = Arc::from_raw(key_expr_ptr);
+        let key_expr_clone = key_expr.deref().clone();
+        std::mem::forget(key_expr);
+        Ok(key_expr_clone)
+    }
 }
 
 #[no_mangle]
@@ -54,7 +91,7 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_auto
     _class: JClass,
     key_expr: JString,
 ) -> *const KeyExpr<'static> {
-    let key_expr_str = match decode_string(&mut env, key_expr) {
+    let key_expr_str = match decode_string(&mut env, &key_expr) {
         Ok(key_expr) => key_expr,
         Err(err) => {
             _ = err.throw_on_jvm(&mut env);

--- a/zenoh-jni/src/key_expr.rs
+++ b/zenoh-jni/src/key_expr.rs
@@ -64,30 +64,6 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_auto
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_getStringValueViaJNI(
-    mut env: JNIEnv,
-    _: JClass,
-    ptr: *const KeyExpr<'static>,
-) -> jstring {
-    let key_expr = Arc::from_raw(ptr);
-    let key_expr_str = match env.new_string(key_expr.to_string()) {
-        Ok(key_expr) => key_expr,
-        Err(err) => {
-            _ = Error::Jni(format!(
-                "Unable to get key expression string value: {}",
-                err
-            ))
-            .throw_on_jvm(&mut env);
-            std::mem::forget(key_expr);
-            return JString::default().as_raw();
-        }
-    };
-    std::mem::forget(key_expr);
-    key_expr_str.as_raw()
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_intersectsViaJNI(
     _env: JNIEnv,
     _: JClass,

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -27,7 +27,7 @@ use zenoh::{
 
 use crate::{
     errors::{Error, Result},
-    key_expr::process_key_expr,
+    key_expr::process_kotlin_key_expr,
     utils::{decode_byte_array, vec_to_attachment},
 };
 use crate::{
@@ -138,7 +138,7 @@ pub(crate) unsafe fn declare_publisher(
     priority: jint,
 ) -> Result<*const Publisher<'static>> {
     let session = Arc::from_raw(session_ptr);
-    let key_expr = process_key_expr(env, &key_expr_str, key_expr_ptr)?;
+    let key_expr = process_kotlin_key_expr(env, &key_expr_str, key_expr_ptr)?;
     let congestion_control = decode_congestion_control(congestion_control)?;
     let priority = decode_priority(priority)?;
     let result = session

--- a/zenoh-jni/src/put.rs
+++ b/zenoh-jni/src/put.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::errors::{Error, Result};
-use crate::key_expr::process_key_expr;
+use crate::key_expr::process_kotlin_key_expr;
 use crate::sample::decode_sample_kind;
 use crate::utils::{decode_byte_array, vec_to_attachment};
 use crate::value::decode_value;
@@ -56,7 +56,7 @@ pub(crate) fn on_put(
     sample_kind: jint,
     attachment: JByteArray,
 ) -> Result<()> {
-    let key_expr = unsafe { process_key_expr(env, &key_expr_str, key_expr_ptr) }?;
+    let key_expr = unsafe { process_kotlin_key_expr(env, &key_expr_str, key_expr_ptr) }?;
     let value = decode_value(env, payload, encoding)?;
     let sample_kind = decode_sample_kind(sample_kind)?;
     let congestion_control = match decode_congestion_control(congestion_control) {

--- a/zenoh-jni/src/query.rs
+++ b/zenoh-jni/src/query.rs
@@ -84,7 +84,7 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
         Err(err) => {
             _ = err
                 .throw_on_jvm(&mut env)
-                .map_err(|err| log::error!("{}", err));
+                .map_err(|err| tracing::error!("{}", err));
             return;
         }
     };
@@ -308,7 +308,7 @@ pub(crate) fn on_query(
 
     _ = env
         .delete_local_ref(key_expr_str)
-        .map_err(|err| log::error!("Error deleting local ref: {}", err));
+        .map_err(|err| tracing::error!("Error deleting local ref: {}", err));
     _ = env
         .delete_local_ref(selector_params_jstr)
         .map_err(|err| tracing::error!("Error deleting local ref: {}", err));

--- a/zenoh-jni/src/queryable.rs
+++ b/zenoh-jni/src/queryable.rs
@@ -24,7 +24,7 @@ use zenoh::{queryable::Queryable, Session};
 
 use crate::{
     errors::{Error, Result},
-    key_expr::process_key_expr,
+    key_expr::process_kotlin_key_expr,
     query::on_query,
     utils::{get_callback_global_ref, get_java_vm, load_on_close},
 };
@@ -86,7 +86,7 @@ pub(crate) unsafe fn declare_queryable(
     let java_vm = Arc::new(get_java_vm(env)?);
     let callback_global_ref = get_callback_global_ref(env, callback)?;
     let on_close_global_ref = get_callback_global_ref(env, on_close)?;
-    let key_expr = process_key_expr(env, &key_expr_str, key_expr_ptr)?;
+    let key_expr = process_kotlin_key_expr(env, &key_expr_str, key_expr_ptr)?;
     let complete = complete != 0;
     let on_close = load_on_close(&java_vm, on_close_global_ref);
     let session: Arc<Session> = Arc::from_raw(session_ptr);

--- a/zenoh-jni/src/queryable.rs
+++ b/zenoh-jni/src/queryable.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use jni::{
     objects::{JClass, JObject, JString},

--- a/zenoh-jni/src/reply.rs
+++ b/zenoh-jni/src/reply.rs
@@ -104,7 +104,7 @@ fn on_reply_success(
 
     _ = env
         .delete_local_ref(key_expr_str)
-        .map_err(|err| log::error!("Error deleting local ref: {}", err));
+        .map_err(|err| tracing::error!("Error deleting local ref: {}", err));
     _ = env
         .delete_local_ref(zenoh_id)
         .map_err(|err| tracing::debug!("Error deleting local ref: {}", err));

--- a/zenoh-jni/src/reply.rs
+++ b/zenoh-jni/src/reply.rs
@@ -12,8 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::sync::Arc;
-
 use jni::{
     objects::{GlobalRef, JObject, JValue},
     sys::jint,

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -211,7 +211,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_closeSessionViaJNI(
 /// Parameters:
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.
-/// - `key_expr`: Raw pointer of the [KeyExpr] to be used for the publisher.
+/// - `key_expr_ptr`: Raw pointer to the [KeyExpr] to be used for the publisher.
+/// - `key_expr_str`: String representation of the [KeyExpr] to be used for the publisher.
+///     It is only considered when the key_expr_ptr parameter is null, meaning the function is
+///     receiving a key expression that was not declared.
 /// - `session_ptr`: The raw pointer to the Zenoh [Session] from which to declare the publisher.
 /// - `congestion_control`: The [CongestionControl] mechanism specified as an ordinal.
 /// - `priority`: The [Priority] mechanism specified as an ordinal.
@@ -233,11 +236,19 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declarePublisherViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     session_ptr: *const zenoh::Session,
     congestion_control: jint,
     priority: jint,
 ) -> *const zenoh::publication::Publisher<'static> {
-    let result = declare_publisher(key_expr_ptr, session_ptr, congestion_control, priority);
+    let result = declare_publisher(
+        &mut env,
+        key_expr_ptr,
+        key_expr_str,
+        session_ptr,
+        congestion_control,
+        priority,
+    );
     match result {
         Ok(ptr) => ptr,
         Err(err) => {

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -385,7 +385,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
 /// Parameters:
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.
-/// - `key_expr_ptr`: A raw pointer to the [KeyExpr] to be used for the queryable.
+/// - `key_expr_ptr`: A raw pointer to the [KeyExpr] to be used for the queryable. May be null in case of using an
+///     undeclared key expression.
+/// - `key_expr_str`: String representation of the key expression to be used to declare the queryable.
+///     It won't be considered in case a key_expr_ptr to a declared key expression is provided.
 /// - `session_ptr`: A raw pointer to the Zenoh [Session] to be used to declare the queryable.
 /// - `callback`: The callback function as an instance of the `JNIQueryableCallback` interface in Java/Kotlin.
 /// - `on_close`: A Java/Kotlin `JNIOnCloseCallback` function interface to be called upon closing the queryable.
@@ -409,6 +412,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQueryableViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     session_ptr: *const zenoh::Session,
     callback: JObject,
     on_close: JObject,
@@ -417,6 +421,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQueryableViaJNI(
     match declare_queryable(
         &mut env,
         key_expr_ptr,
+        key_expr_str,
         session_ptr,
         callback,
         on_close,

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -260,6 +260,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declarePublisherViaJNI(
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.
 /// - `key_expr_ptr`: Raw pointer to the [KeyExpr] to be used for the operation.
+/// - `key_expr_str`: String representation of the [KeyExpr] to be used for the operation.
+///     It is only considered when the key_expr_ptr parameter is null, meaning the function is
+///     receiving a key expression that was not declared.
 /// - `session_ptr`: Raw pointer to the [Session] to be used for the operation.
 /// - `payload`: The payload to send through the network.
 /// - `encoding`: The [Encoding] of the put operation.
@@ -282,6 +285,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     session_ptr: *const zenoh::Session,
     payload: JByteArray,
     encoding: jint,
@@ -291,10 +295,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
     attachment: JByteArray,
 ) {
     let session = Arc::from_raw(session_ptr);
-    let key_expr = Arc::from_raw(key_expr_ptr);
     match on_put(
         &mut env,
-        &key_expr,
+        key_expr_ptr,
+        key_expr_str,
         &session,
         payload,
         encoding,
@@ -314,7 +318,6 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
         }
     }
     std::mem::forget(session);
-    std::mem::forget(key_expr);
 }
 
 /// Declare a Zenoh subscriber via JNI.

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -120,7 +120,7 @@ pub extern "C" fn Java_io_zenoh_jni_JNISession_openSessionWithJsonConfigViaJNI(
 /// - A [Result] with a [zenoh::Session] in case of success or an [Error::Session] in case of failure.
 ///
 fn open_session(env: &mut JNIEnv, config_path: JString) -> Result<zenoh::Session> {
-    let config_file_path = decode_string(env, config_path)?;
+    let config_file_path = decode_string(env, &config_path)?;
     let config = if config_file_path.is_empty() {
         Config::default()
     } else {
@@ -140,7 +140,7 @@ fn open_session(env: &mut JNIEnv, config_path: JString) -> Result<zenoh::Session
 /// - A [Result] with a [zenoh::Session] in case of success or an [Error::Session] in case of failure.
 ///
 fn open_session_with_json_config(env: &mut JNIEnv, json_config: JString) -> Result<zenoh::Session> {
-    let json_config = decode_string(env, json_config)?;
+    let json_config = decode_string(env, &json_config)?;
     let config = if json_config.is_empty() {
         Config::default()
     } else {
@@ -695,7 +695,7 @@ fn on_get_query(
     let on_close_global_ref = get_callback_global_ref(env, on_close)?;
     let query_target = decode_query_target(target)?;
     let consolidation = decode_consolidation(consolidation)?;
-    let selector_params = decode_string(env, selector_params)?;
+    let selector_params = decode_string(env, &selector_params)?;
     let timeout = Duration::from_millis(timeout_ms as u64);
     let on_close = load_on_close(&java_vm, on_close_global_ref);
 
@@ -751,7 +751,7 @@ pub(crate) unsafe fn declare_keyexpr(
     session_ptr: *const Session,
     key_expr: JString,
 ) -> Result<KeyExpr<'static>> {
-    let key_expr = decode_string(env, key_expr)?;
+    let key_expr = decode_string(env, &key_expr)?;
     let session: Arc<Session> = Arc::from_raw(session_ptr);
     let result = session.declare_keyexpr(key_expr.to_owned()).res();
     std::mem::forget(session);

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -13,6 +13,7 @@
 //
 
 use crate::errors::{Error, Result};
+use crate::key_expr::process_key_expr;
 use crate::publisher::declare_publisher;
 use crate::put::on_put;
 use crate::query::{decode_consolidation, decode_query_target};
@@ -534,7 +535,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_undeclareKeyExprViaJNI(
 /// Parameters:
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.
-/// - `key_expr`: Pointer to the key expression for the `get`.
+/// - `key_expr_ptr`: Raw pointer to a declared [KeyExpr] to be used for the query. May be null in case
+///     of using a non declared key expression, in which case the key_expr_str parameter will be used instead.
+/// - `key_expr_str`: String representation of the key expression to be used for the query. It is not
+///     considered if a key_expr_ptr is provided.
 /// - `selector_params`: Parameters of the selector.
 /// - `session_ptr`: A raw pointer to the Zenoh session.
 /// - `callback`: An instance of the Java/Kotlin `JNIGetCallback` function interface to be called upon receiving a reply.
@@ -560,7 +564,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_undeclareKeyExprViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr: *const KeyExpr<'static>,
+    key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     selector_params: JString,
     session_ptr: *const zenoh::Session,
     callback: JObject,
@@ -571,10 +576,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
     attachment: JByteArray,
 ) {
     let session = Arc::from_raw(session_ptr);
-    let key_expr = Arc::from_raw(key_expr);
     match on_get_query(
         &mut env,
-        &key_expr,
+        key_expr_ptr,
+        key_expr_str,
         selector_params,
         &session,
         callback,
@@ -596,7 +601,6 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
         }
     }
     std::mem::forget(session);
-    std::mem::forget(key_expr);
 }
 
 /// Performs a `get` operation in the Zenoh session via JNI with Value.
@@ -606,7 +610,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
 /// Parameters:
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.
-/// - `key_expr_ptr`: A raw pointer to the [KeyExpr] to be used for the operation.
+/// - `key_expr_ptr`: Raw pointer to a declared [KeyExpr] to be used for the query. May be null in case
+///     of using a non declared key expression, in which case the key_expr_str parameter will be used instead.
+/// - `key_expr_str`: String representation of the key expression to be used to declare the query. It is not
+///     considered if a key_expr_ptr is provided.
 /// - `selector_params`: Parameters of the selector.
 /// - `session_ptr`: A raw pointer to the Zenoh [Session].
 /// - `callback`: A Java/Kotlin callback to be called upon receiving a reply.
@@ -634,6 +641,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getWithValueViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     selector_params: JString,
     session_ptr: *const zenoh::Session,
     callback: JObject,
@@ -646,10 +654,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getWithValueViaJNI(
     attachment: JByteArray,
 ) {
     let session = Arc::from_raw(session_ptr);
-    let key_expr = Arc::from_raw(key_expr_ptr);
     match on_get_query(
         &mut env,
-        &key_expr,
+        key_expr_ptr,
+        key_expr_str,
         selector_params,
         &session,
         callback,
@@ -671,14 +679,16 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getWithValueViaJNI(
         }
     }
     std::mem::forget(session);
-    std::mem::forget(key_expr);
 }
 
 /// Performs a `get` operation in the Zenoh session via JNI.
 ///
 /// Parameters:
 /// - `env`: A mutable reference to the JNI environment.
-/// - `key_expr`: The key expression for the `get` operation.
+/// - `key_expr_ptr`: Raw pointer to a declared [KeyExpr] to be used for the query. May be null in case
+///     of using a non declared key expression, in which case the key_expr_str parameter will be used instead.
+/// - `key_expr_str`: String representation of the key expression to be used to declare the query. It is not
+///     considered if a key_expr_ptr is provided.
 /// - `session`: An `Arc<Session>` representing the Zenoh session.
 /// - `callback`: A Java/Kotlin `JNIGetCallback` function interface to be called upon receiving a reply.
 /// - `on_close`: A Java/Kotlin `JNIOnCloseCallback` function interface to be called when Zenoh notifies
@@ -696,7 +706,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getWithValueViaJNI(
 #[allow(clippy::too_many_arguments)]
 fn on_get_query(
     env: &mut JNIEnv,
-    key_expr: &Arc<KeyExpr<'static>>,
+    key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_str: JString,
     selector_params: JString,
     session: &Arc<Session>,
     callback: JObject,
@@ -707,6 +718,7 @@ fn on_get_query(
     value_params: Option<(JByteArray, jint)>,
     encoded_attachment: JByteArray,
 ) -> Result<()> {
+    let key_expr = unsafe { process_key_expr(env, &key_expr_str, key_expr_ptr) }?;
     let java_vm = Arc::new(get_java_vm(env)?);
     let callback_global_ref = get_callback_global_ref(env, callback)?;
     let on_close_global_ref = get_callback_global_ref(env, on_close)?;
@@ -715,9 +727,7 @@ fn on_get_query(
     let selector_params = decode_string(env, &selector_params)?;
     let timeout = Duration::from_millis(timeout_ms as u64);
     let on_close = load_on_close(&java_vm, on_close_global_ref);
-
-    let key_expr_clone = key_expr.deref().clone();
-    let selector = Selector::from(key_expr_clone).with_parameters(&selector_params);
+    let selector = Selector::from(&key_expr).with_parameters(&selector_params);
     let mut get_builder = session
         .get(selector)
         .callback(move |reply| {

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::errors::{Error, Result};
-use crate::key_expr::process_key_expr;
+use crate::key_expr::process_kotlin_key_expr;
 use crate::publisher::declare_publisher;
 use crate::put::on_put;
 use crate::query::{decode_consolidation, decode_query_target};
@@ -732,7 +732,7 @@ fn on_get_query(
     value_params: Option<(JByteArray, jint)>,
     encoded_attachment: JByteArray,
 ) -> Result<()> {
-    let key_expr = unsafe { process_key_expr(env, &key_expr_str, key_expr_ptr) }?;
+    let key_expr = unsafe { process_kotlin_key_expr(env, &key_expr_str, key_expr_ptr) }?;
     let java_vm = Arc::new(get_java_vm(env)?);
     let callback_global_ref = get_callback_global_ref(env, callback)?;
     let on_close_global_ref = get_callback_global_ref(env, on_close)?;

--- a/zenoh-jni/src/subscriber.rs
+++ b/zenoh-jni/src/subscriber.rs
@@ -22,7 +22,6 @@ use jni::{
 use zenoh::prelude::r#sync::*;
 use zenoh::subscriber::Subscriber;
 
-use crate::utils::{get_callback_global_ref, get_java_vm, load_on_close};
 use crate::{
     errors::{Error, Result},
     utils::attachment_to_vec,

--- a/zenoh-jni/src/subscriber.rs
+++ b/zenoh-jni/src/subscriber.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use jni::{
     objects::{JClass, JObject, JString, JValue},
-    sys::{jint, jlong},
+    sys::jint,
     JNIEnv,
 };
 use zenoh::prelude::r#sync::*;
@@ -27,8 +27,8 @@ use crate::{
     utils::attachment_to_vec,
 };
 use crate::{
-    sample::qos_into_jbyte,
     key_expr::process_kotlin_key_expr,
+    sample::qos_into_jbyte,
     utils::{get_callback_global_ref, get_java_vm, load_on_close},
 };
 

--- a/zenoh-jni/src/utils.rs
+++ b/zenoh-jni/src/utils.rs
@@ -23,9 +23,9 @@ use zenoh::sample::{Attachment, AttachmentBuilder};
 use crate::errors::{Error, Result};
 
 /// Converts a JString into a rust String.
-pub(crate) fn decode_string(env: &mut JNIEnv, string: JString) -> Result<String> {
+pub(crate) fn decode_string(env: &mut JNIEnv, string: &JString) -> Result<String> {
     let binding = env
-        .get_string(&string)
+        .get_string(string)
         .map_err(|err| Error::Jni(format!("Error while retrieving JString: {}", err)))?;
     let value = binding
         .to_str()

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -37,6 +37,13 @@ internal class JNIKeyExpr(internal val ptr: Long) {
             keyExprB.keyExpr
         )
 
+        fun includes(keyExprA: KeyExpr, keyExprB: KeyExpr): Boolean = includesViaJNI(
+            keyExprA.jniKeyExpr?.ptr ?: 0,
+            keyExprA.keyExpr,
+            keyExprB.jniKeyExpr?.ptr ?: 0,
+            keyExprB.keyExpr
+        )
+
         @Throws(Exception::class)
         private external fun tryFromViaJNI(keyExpr: String): String
 
@@ -45,20 +52,14 @@ internal class JNIKeyExpr(internal val ptr: Long) {
 
         @Throws(Exception::class)
         private external fun intersectsViaJNI(ptrA: Long, keyExprA: String, ptrB: Long, keyExprB: String): Boolean
-    }
 
-    fun includes(other: KeyExpr): Boolean {
-        if (other.jniKeyExpr == null) {
-            return false
-        }
-        return includesViaJNI(ptr, other.jniKeyExpr!!.ptr)
+        @Throws(Exception::class)
+        private external fun includesViaJNI(ptrA: Long, keyExprA: String, ptrB: Long, keyExprB: String): Boolean
     }
 
     fun close() {
         freePtrViaJNI(ptr)
     }
-
-    private external fun includesViaJNI(ptrA: Long, ptrB: Long): Boolean
 
     /** Frees the underlying native KeyExpr. */
     private external fun freePtrViaJNI(ptr: Long)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -30,18 +30,21 @@ internal class JNIKeyExpr(internal val ptr: Long) {
             KeyExpr(autocanonizeViaJNI(keyExpr))
         }
 
+        fun intersects(keyExprA: KeyExpr, keyExprB: KeyExpr): Boolean = intersectsViaJNI(
+            keyExprA.jniKeyExpr?.ptr ?: 0,
+            keyExprA.keyExpr,
+            keyExprB.jniKeyExpr?.ptr ?: 0,
+            keyExprB.keyExpr
+        )
+
         @Throws(Exception::class)
         private external fun tryFromViaJNI(keyExpr: String): String
 
         @Throws(Exception::class)
         private external fun autocanonizeViaJNI(keyExpr: String): String
-    }
 
-    fun intersects(other: KeyExpr): Boolean {
-        if (other.jniKeyExpr == null) {
-            return false
-        }
-        return intersectsViaJNI(ptr, other.jniKeyExpr!!.ptr)
+        @Throws(Exception::class)
+        private external fun intersectsViaJNI(ptrA: Long, keyExprA: String, ptrB: Long, keyExprB: String): Boolean
     }
 
     fun includes(other: KeyExpr): Boolean {
@@ -54,8 +57,6 @@ internal class JNIKeyExpr(internal val ptr: Long) {
     fun close() {
         freePtrViaJNI(ptr)
     }
-
-    private external fun intersectsViaJNI(ptrA: Long, ptrB: Long): Boolean
 
     private external fun includesViaJNI(ptrA: Long, ptrB: Long): Boolean
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -22,8 +22,7 @@ internal class JNIKeyExpr(internal val ptr: Long) {
     companion object {
         fun tryFrom(keyExpr: String): Result<KeyExpr> = runCatching {
             Zenoh.load() // It may happen the zenoh library is not yet loaded when creating a key expression.
-            val keyExprPtr = tryFromViaJNI(keyExpr)
-            KeyExpr(keyExpr, JNIKeyExpr(keyExprPtr))
+            KeyExpr(tryFromViaJNI(keyExpr))
         }
 
         fun autocanonize(keyExpr: String): Result<KeyExpr> = runCatching {
@@ -34,7 +33,7 @@ internal class JNIKeyExpr(internal val ptr: Long) {
         }
 
         @Throws(Exception::class)
-        private external fun tryFromViaJNI(keyExpr: String): Long
+        private external fun tryFromViaJNI(keyExpr: String): String
 
         @Throws(Exception::class)
         private external fun autocanonizeViaJNI(keyExpr: String): Long
@@ -82,7 +81,7 @@ internal class JNIKeyExpr(internal val ptr: Long) {
     private external fun includesViaJNI(ptrA: Long, ptrB: Long): Boolean
 
     @Throws(Exception::class)
-    private external fun getStringValueViaJNI(ptr: Long): String
+    private external fun getStringValueViaJNI(ptr: Long): String //TODO: remove
 
     /** Frees the underlying native KeyExpr. */
     private external fun freePtrViaJNI(ptr: Long)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -23,13 +23,14 @@ internal class JNIKeyExpr(internal val ptr: Long) {
         fun tryFrom(keyExpr: String): Result<KeyExpr> = runCatching {
             Zenoh.load() // It may happen the zenoh library is not yet loaded when creating a key expression.
             val keyExprPtr = tryFromViaJNI(keyExpr)
-            KeyExpr(JNIKeyExpr(keyExprPtr))
+            KeyExpr(keyExpr, JNIKeyExpr(keyExprPtr))
         }
 
         fun autocanonize(keyExpr: String): Result<KeyExpr> = runCatching {
             Zenoh.load()
             val keyExprPtr = autocanonizeViaJNI(keyExpr)
-            KeyExpr(JNIKeyExpr(keyExprPtr))
+            val jniKeyExpr = JNIKeyExpr(keyExprPtr)
+            KeyExpr(jniKeyExpr.toString(), jniKeyExpr)
         }
 
         @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -27,16 +27,14 @@ internal class JNIKeyExpr(internal val ptr: Long) {
 
         fun autocanonize(keyExpr: String): Result<KeyExpr> = runCatching {
             Zenoh.load()
-            val keyExprPtr = autocanonizeViaJNI(keyExpr)
-            val jniKeyExpr = JNIKeyExpr(keyExprPtr)
-            KeyExpr(jniKeyExpr.toString(), jniKeyExpr)
+            KeyExpr(autocanonizeViaJNI(keyExpr))
         }
 
         @Throws(Exception::class)
         private external fun tryFromViaJNI(keyExpr: String): String
 
         @Throws(Exception::class)
-        private external fun autocanonizeViaJNI(keyExpr: String): Long
+        private external fun autocanonizeViaJNI(keyExpr: String): String
     }
 
     override fun toString(): String {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -37,10 +37,6 @@ internal class JNIKeyExpr(internal val ptr: Long) {
         private external fun autocanonizeViaJNI(keyExpr: String): String
     }
 
-    override fun toString(): String {
-        return getStringValueViaJNI(ptr)
-    }
-
     fun intersects(other: KeyExpr): Boolean {
         if (other.jniKeyExpr == null) {
             return false
@@ -77,9 +73,6 @@ internal class JNIKeyExpr(internal val ptr: Long) {
     private external fun intersectsViaJNI(ptrA: Long, ptrB: Long): Boolean
 
     private external fun includesViaJNI(ptrA: Long, ptrB: Long): Boolean
-
-    @Throws(Exception::class)
-    private external fun getStringValueViaJNI(ptr: Long): String //TODO: remove
 
     /** Frees the underlying native KeyExpr. */
     private external fun freePtrViaJNI(ptr: Long)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIKeyExpr.kt
@@ -55,21 +55,6 @@ internal class JNIKeyExpr(internal val ptr: Long) {
         freePtrViaJNI(ptr)
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as JNIKeyExpr
-
-        return equalsViaJNI(ptr, other.ptr)
-    }
-
-    override fun hashCode(): Int {
-        return ptr.hashCode()
-    }
-
-    private external fun equalsViaJNI(ptrA: Long, ptrB: Long): Boolean
-
     private external fun intersectsViaJNI(ptrA: Long, ptrB: Long): Boolean
 
     private external fun includesViaJNI(ptrA: Long, ptrB: Long): Boolean

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuery.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuery.kt
@@ -30,7 +30,8 @@ internal class JNIQuery(private val ptr: Long) {
         val timestampEnabled = sample.timestamp != null
         replySuccessViaJNI(
             ptr,
-            sample.keyExpr.jniKeyExpr!!.ptr,
+            sample.keyExpr.jniKeyExpr?.ptr ?: 0,
+            sample.keyExpr.keyExpr,
             sample.value.payload,
             sample.value.encoding.knownEncoding.ordinal,
             sample.kind.ordinal,
@@ -52,7 +53,8 @@ internal class JNIQuery(private val ptr: Long) {
     @Throws(Exception::class)
     private external fun replySuccessViaJNI(
         queryPtr: Long,
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         valuePayload: ByteArray,
         valueEncoding: Int,
         sampleKind: Int,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -91,7 +91,7 @@ internal class JNISession {
                 callback.run(sample)
             }
         val subscriberRawPtr = declareSubscriberViaJNI(
-            keyExpr.jniKeyExpr!!.ptr, sessionPtr.get(), subCallback, onClose, reliability.ordinal //TODO: If the key expression was not declared, declare it and pass the pointer.
+            keyExpr.jniKeyExpr?.ptr ?: 0, keyExpr.keyExpr, sessionPtr.get(), subCallback, onClose, reliability.ordinal
         )
         Subscriber(keyExpr, receiver, JNISubscriber(subscriberRawPtr))
     }
@@ -182,6 +182,7 @@ internal class JNISession {
     }
 
     fun undeclareKeyExpr(keyExpr: KeyExpr): Result<Unit> = runCatching {
+        // TODO(https://github.com/eclipse-zenoh/zenoh-kotlin/issues/75): fix key expr could be undeclared twice!
         undeclareKeyExprViaJNI(sessionPtr.get(), keyExpr.jniKeyExpr!!.ptr)
     }
 
@@ -217,7 +218,8 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun declareSubscriberViaJNI(
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         sessionPtr: Long,
         callback: JNISubscriberCallback,
         onClose: JNIOnCloseCallback,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -81,7 +81,7 @@ internal class JNISession {
                 val timestamp = if (timestampIsValid) TimeStamp(timestampNTP64) else null
                 val attachment = attachmentBytes.takeIf { it.isNotEmpty() }?.let { decodeAttachment(it) }
                 val sample = Sample(
-                    KeyExpr(JNIKeyExpr(keyExprPtr)),
+                    KeyExpr("", JNIKeyExpr(keyExprPtr)), // TODO: receive String Key Expr through JNI
                     Value(payload, Encoding(KnownEncoding.fromInt(encoding))),
                     SampleKind.fromInt(kind),
                     timestamp,
@@ -102,7 +102,7 @@ internal class JNISession {
         val queryCallback =
             JNIQueryableCallback { keyExprPtr: Long, selectorParams: String, withValue: Boolean, payload: ByteArray?, encoding: Int, attachmentBytes: ByteArray, queryPtr: Long ->
                 val jniQuery = JNIQuery(queryPtr)
-                val keyExpression = KeyExpr(JNIKeyExpr(keyExprPtr))
+                val keyExpression = KeyExpr("", JNIKeyExpr(keyExprPtr)) // TODO: receive String Key Expr through JNI
                 val selector = Selector(keyExpression, selectorParams)
                 val value: Value? = if (withValue) Value(payload!!, Encoding(KnownEncoding.fromInt(encoding))) else null
                 val decodedAttachment = attachmentBytes.takeIf { it.isNotEmpty() }?.let { decodeAttachment(it) }
@@ -131,7 +131,7 @@ internal class JNISession {
                     val timestamp = if (timestampIsValid) TimeStamp(timestampNTP64) else null
                     val decodedAttachment = attachmentBytes.takeIf { it.isNotEmpty() }?.let { decodeAttachment(it) }
                     val sample = Sample(
-                        KeyExpr(JNIKeyExpr(keyExprPtr)),
+                        KeyExpr("", JNIKeyExpr(keyExprPtr)), // TODO: receive String Key Expr through JNI
                         Value(payload, Encoding(KnownEncoding.fromInt(encoding))),
                         SampleKind.fromInt(kind),
                         timestamp,
@@ -178,7 +178,7 @@ internal class JNISession {
 
     fun declareKeyExpr(keyExpr: String): Result<KeyExpr> = runCatching {
         val ptr = declareKeyExprViaJNI(sessionPtr.get(), keyExpr)
-        return Result.success(KeyExpr(JNIKeyExpr(ptr)))
+        return Result.success(KeyExpr(keyExpr, JNIKeyExpr(ptr)))
     }
 
     fun undeclareKeyExpr(keyExpr: KeyExpr): Result<Unit> = runCatching {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -148,7 +148,8 @@ internal class JNISession {
 
         if (value == null) {
             getViaJNI(
-                selector.keyExpr.jniKeyExpr!!.ptr,//TODO: If the key expression was not declared, declare it and pass the pointer.
+                selector.keyExpr.jniKeyExpr?.ptr ?: 0,
+                selector.keyExpr.keyExpr,
                 selector.parameters,
                 sessionPtr.get(),
                 getCallback,
@@ -160,7 +161,8 @@ internal class JNISession {
             )
         } else {
             getWithValueViaJNI(
-                selector.keyExpr.jniKeyExpr!!.ptr,//TODO: If the key expression was not declared, declare it and pass the pointer.
+                selector.keyExpr.jniKeyExpr?.ptr ?: 0,
+                selector.keyExpr.keyExpr,
                 selector.parameters,
                 sessionPtr.get(),
                 getCallback,
@@ -244,7 +246,8 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun getViaJNI(
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         selectorParams: String,
         sessionPtr: Long,
         callback: JNIGetCallback,
@@ -257,7 +260,8 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun getWithValueViaJNI(
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         selectorParams: String,
         sessionPtr: Long,
         callback: JNIGetCallback,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -15,6 +15,7 @@
 package io.zenoh.jni
 
 import io.zenoh.*
+import io.zenoh.exceptions.SessionException
 import io.zenoh.handlers.Callback
 import io.zenoh.jni.callbacks.JNIOnCloseCallback
 import io.zenoh.prelude.KnownEncoding
@@ -185,8 +186,10 @@ internal class JNISession {
     }
 
     fun undeclareKeyExpr(keyExpr: KeyExpr): Result<Unit> = runCatching {
-        // TODO(https://github.com/eclipse-zenoh/zenoh-kotlin/issues/75): fix key expr could be undeclared twice!
-        undeclareKeyExprViaJNI(sessionPtr.get(), keyExpr.jniKeyExpr!!.ptr)
+        keyExpr.jniKeyExpr?.run {
+            undeclareKeyExprViaJNI(sessionPtr.get(), this.ptr)
+            keyExpr.close()
+        } ?: throw SessionException("Attempting to undeclare a non declared key expression.")
     }
 
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -60,7 +60,8 @@ internal class JNISession {
 
     fun declarePublisher(builder: Publisher.Builder): Result<Publisher> = runCatching {
         val publisherRawPtr = declarePublisherViaJNI(
-            builder.keyExpr.jniKeyExpr!!.ptr,
+            builder.keyExpr.jniKeyExpr?.ptr ?: 0,
+            builder.keyExpr.keyExpr,
             sessionPtr.get(),
             builder.congestionControl.value,
             builder.priority.value,
@@ -216,7 +217,11 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun declarePublisherViaJNI(
-        keyExpr: Long, ptr: Long, congestionControl: Int, priority: Int
+        keyExprPtr: Long,
+        keyExprString: String,
+        sessionPtr: Long,
+        congestionControl: Int,
+        priority: Int
     ): Long
 
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -110,7 +110,7 @@ internal class JNISession {
                 callback.run(query)
             }
         val queryableRawPtr =
-            declareQueryableViaJNI(keyExpr.jniKeyExpr!!.ptr, sessionPtr.get(), queryCallback, onClose, complete) //TODO: If the key expression was not declared, declare it and pass the pointer.
+            declareQueryableViaJNI(keyExpr.jniKeyExpr?.ptr ?: 0, keyExpr.keyExpr, sessionPtr.get(), queryCallback, onClose, complete)
         Queryable(keyExpr, receiver, JNIQueryable(queryableRawPtr))
     }
 
@@ -228,7 +228,8 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun declareQueryableViaJNI(
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         sessionPtr: Long,
         callback: JNIQueryableCallback,
         onClose: JNIOnCloseCallback,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -194,7 +194,8 @@ internal class JNISession {
         put: Put,
     ) {
         putViaJNI(
-            keyExpr.jniKeyExpr!!.ptr,
+            keyExpr.jniKeyExpr?.ptr ?: 0,
+            keyExpr.keyExpr,
             sessionPtr.get(),
             put.value.payload,
             put.value.encoding.knownEncoding.ordinal,
@@ -276,7 +277,8 @@ internal class JNISession {
 
     @Throws(Exception::class)
     private external fun putViaJNI(
-        keyExpr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
         sessionPtr: Long,
         valuePayload: ByteArray,
         valueEncoding: Int,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
@@ -19,7 +19,7 @@ internal fun interface JNIGetCallback {
     fun run(
         replierId: String,
         success: Boolean,
-        keyExpr: Long,
+        keyExpr: String,
         payload: ByteArray,
         encoding: Int,
         kind: Int,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIQueryableCallback.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIQueryableCallback.kt
@@ -15,7 +15,7 @@
 package io.zenoh.jni.callbacks
 
 internal fun interface JNIQueryableCallback {
-    fun run(keyExprPtr: Long,
+    fun run(keyExpr: String,
             selectorParams: String,
             withValue: Boolean,
             payload: ByteArray?,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNISubscriberCallback.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNISubscriberCallback.kt
@@ -16,7 +16,7 @@ package io.zenoh.jni.callbacks
 
 internal fun interface JNISubscriberCallback {
     fun run(
-        keyExpr: Long,
+        keyExpr: String,
         payload: ByteArray,
         encoding: Int,
         kind: Int,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -58,7 +58,7 @@ import io.zenoh.jni.JNIKeyExpr
  * includes, etc.) which are done natively. It keeps track of the underlying key expression instance. Once it is freed,
  * the [KeyExpr] instance is considered to not be valid anymore.
  */
-class KeyExpr internal constructor(val keyExpr: String, internal var jniKeyExpr: JNIKeyExpr? = null): AutoCloseable {
+class KeyExpr internal constructor(internal val keyExpr: String, internal var jniKeyExpr: JNIKeyExpr? = null): AutoCloseable {
 
     companion object {
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -58,7 +58,7 @@ import io.zenoh.jni.JNIKeyExpr
  * includes, etc.) which are done natively. It keeps track of the underlying key expression instance. Once it is freed,
  * the [KeyExpr] instance is considered to not be valid anymore.
  */
-class KeyExpr internal constructor(internal var jniKeyExpr: JNIKeyExpr? = null): AutoCloseable {
+class KeyExpr internal constructor(val keyExpr: String, internal var jniKeyExpr: JNIKeyExpr? = null): AutoCloseable {
 
     companion object {
 
@@ -127,7 +127,7 @@ class KeyExpr internal constructor(internal var jniKeyExpr: JNIKeyExpr? = null):
     }
 
     override fun toString(): String {
-        return this.jniKeyExpr?.toString() ?: ""
+        return keyExpr
     }
 
     /**
@@ -148,12 +148,11 @@ class KeyExpr internal constructor(internal var jniKeyExpr: JNIKeyExpr? = null):
         if (javaClass != other?.javaClass) return false
 
         other as KeyExpr
-        if (jniKeyExpr == null || other.jniKeyExpr == null) return false
 
-        return jniKeyExpr == other.jniKeyExpr
+        return keyExpr == other.keyExpr
     }
 
     override fun hashCode(): Int {
-        return jniKeyExpr?.hashCode() ?: 0
+        return keyExpr.hashCode()
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -106,7 +106,7 @@ class KeyExpr internal constructor(internal val keyExpr: String, internal var jn
      * Will return false as well if the key expression is not valid anymore.
      */
     fun includes(other: KeyExpr): Boolean {
-        return jniKeyExpr?.includes(other) ?: false
+        return JNIKeyExpr.includes(this, other)
     }
 
     /**

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -97,7 +97,7 @@ class KeyExpr internal constructor(internal val keyExpr: String, internal var jn
      * Will return false as well if the key expression is not valid anymore.
      */
     fun intersects(other: KeyExpr): Boolean {
-        return jniKeyExpr?.intersects(other) ?: false
+         return JNIKeyExpr.intersects(this, other)
     }
 
     /**

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/KeyExprTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/KeyExprTest.kt
@@ -116,11 +116,16 @@ class KeyExprTest {
         val undeclare1 = session.undeclare(keyExpr).res()
         assertTrue(undeclare1.isSuccess)
 
-        // Undeclaring a key expr that was not declared through a session.
-        val keyExpr2 = "x/y/z".intoKeyExpr().getOrThrow()
-        val undeclare2 = session.undeclare(keyExpr2).res()
+        // Undeclaring twice a key expression shall fail.
+        val undeclare2 = session.undeclare(keyExpr).res()
         assertTrue(undeclare2.isFailure)
         assertTrue(undeclare2.exceptionOrNull() is SessionException)
+
+        // Undeclaring a key expr that was not declared through a session.
+        val keyExpr2 = "x/y/z".intoKeyExpr().getOrThrow()
+        val undeclare3 = session.undeclare(keyExpr2).res()
+        assertTrue(undeclare3.isFailure)
+        assertTrue(undeclare3.exceptionOrNull() is SessionException)
 
         session.close()
         keyExpr.close()

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/KeyExprTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/KeyExprTest.kt
@@ -52,10 +52,10 @@ class KeyExprTest {
         assertNotEquals(keyExpr1, keyExpr3)
 
         keyExpr2.close()
-        assertNotEquals(keyExpr1, keyExpr2)
+        assertEquals(keyExpr1, keyExpr2)
 
         keyExpr1.close()
-        assertNotEquals(keyExpr1, keyExpr2)
+        assertEquals(keyExpr1, keyExpr2)
     }
 
     @Test
@@ -69,11 +69,9 @@ class KeyExprTest {
     fun toStringTest() {
         val keyExprStr = "example/test/a/b/c"
         val keyExpr = KeyExpr.tryFrom(keyExprStr).getOrThrow()
-
         assertEquals(keyExprStr, keyExpr.toString())
-
         keyExpr.close()
-        assertTrue(keyExpr.toString().isEmpty())
+        assertEquals(keyExprStr, keyExpr.toString())
     }
 
     @Test

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SubscriberTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SubscriberTest.kt
@@ -111,6 +111,24 @@ class SubscriberTest {
         subscriber.close()
     }
 
+    @Test
+    fun subscriber_isDeclaredWithNonDeclaredKeyExpression() {
+        // Declaring a subscriber with an undeclared key expression and verifying it properly receives samples.
+        val keyExpr = KeyExpr("example/**")
+        val session = Session.open().getOrThrow()
+
+        val receivedSamples = ArrayList<Sample>()
+        val subscriber = session.declareSubscriber(keyExpr).with { sample -> receivedSamples.add(sample) }.res().getOrThrow()
+        publishTestValues(session)
+        subscriber.close()
+
+        assertEquals(receivedSamples.size, testValues.size)
+
+        for ((index, sample) in receivedSamples.withIndex()) {
+            assertEquals(sample.value, testValues[index])
+        }
+    }
+
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun onCloseTest() = runBlocking {

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SubscriberTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SubscriberTest.kt
@@ -119,7 +119,7 @@ class SubscriberTest {
 
         val receivedSamples = ArrayList<Sample>()
         val subscriber = session.declareSubscriber(keyExpr).with { sample -> receivedSamples.add(sample) }.res().getOrThrow()
-        publishTestValues(session)
+        testValues.forEach { value -> session.put(testKeyExpr, value).res() }
         subscriber.close()
 
         assertEquals(receivedSamples.size, testValues.size)


### PR DESCRIPTION
This PR addresses a series of issues caused by a design flaw of the `KeyExpr` class.

---

The previous design of the KeyExpr class made that everyone of its instances had to be associated to a native key expression through the means of a pointer in order for it to be a valid instance. This caused an overly reliance on the `finalize()` function in order to free the native pointer, which is highly impactful in cases of high frequency communication due to the fact that the finalize `function` messes with all the garbage collector's optimisations, causing the instances of key expressions to not be freed as fast as they are allocated due to incoming samples. 

This PR introduces changes on the architecture of the `KeyExpr` class that aim to fix that issue. It now relies mostly on a string representation of the key expression, stored as an attribute. We still let the user have associated a pointer to a native key expression, but only when declaring it from a session. This is useful for cases where we can anticipate a recurrent usage of a KeyExpr instance, but for those cases it will be up to the user to free the native pointer by calling `session.undeclare(keyexpr).res()`. 

Otherwise, key expressions will simply rely on the string representation to achieve its behaviour, passing the string attribute to the native layer. This is less efficient but simplifies the memory management, allowing us to purely rely on the garbage collector. Similarly and with the same goal in mind, short lived instances of key expressions that are generated from the native layer (like when receiving a Sample from a subscriber) will contain just the string representation of it (without a pointer to a native keyexpr).

Closes #88 
Closes #75 