### PR TITLE
Removing setPriority and setCongestionControl from publisher + adding express config to publisher builder

### DIFF
--- a/zenoh-jni/Cargo.lock
+++ b/zenoh-jni/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "humantime"
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "serde",
  "tracing",
@@ -3528,12 +3528,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "flume 0.11.0",
  "json5",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "aes",
  "hmac",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "bincode",
  "flume 0.11.0",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "flume 0.11.0",
@@ -3654,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "futures",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "const_format",
  "libloading",
@@ -3821,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "const_format",
  "rand",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "anyhow",
 ]
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "event-listener 4.0.3",
  "futures",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "futures",
  "tokio",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-trait",
  "flume 0.11.0",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#bca5c4dc0329a00a1759adbb1806b7e90e102cab"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=dev/1.0.0#f19741bc5898d36dfd7df3955278648f54e61910"
 dependencies = [
  "async-std",
  "async-trait",

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -16,25 +16,19 @@ use std::sync::Arc;
 
 use jni::{
     objects::{JByteArray, JClass, JString},
-    sys::{jboolean, jint},
+    sys::jint,
     JNIEnv,
 };
 use zenoh::{
-    key_expr::KeyExpr,
     prelude::Wait,
     publisher::Publisher,
-    sample::{QoSBuilderTrait, SampleBuilderTrait, ValueBuilderTrait},
-    session::{Session, SessionDeclarations},
+    sample::{SampleBuilderTrait, ValueBuilderTrait},
 };
 
+use crate::throw_exception;
 use crate::{
     errors::{Error, Result},
-    key_expr::process_kotlin_key_expr,
     utils::{decode_byte_array, decode_encoding},
-};
-use crate::{
-    throw_exception,
-    utils::{decode_congestion_control, decode_priority},
 };
 
 /// Performs a put operation on a Zenoh publisher via JNI.
@@ -108,134 +102,6 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_freePtrViaJNI(
     ptr: *const Publisher,
 ) {
     Arc::from_raw(ptr);
-}
-
-/// Declares a Zenoh publisher via JNI.
-///
-/// Parameters:
-/// - `env`: A mutable reference to the JNI environment.
-/// - `key_expr_ptr`: Raw pointer to the [KeyExpr] to be used for the publisher.
-/// - `key_expr_str`: String representation of the [KeyExpr] to be used for the publisher.
-///     It is only considered when the key_expr_ptr parameter is null, meaning the function is
-///     receiving a key expression that was not declared.
-/// - `session_ptr`: Raw pointer to the Zenoh [Session] to be used for the publisher.
-/// - `congestion_control`: The [zenoh::publisher::CongestionControl] configuration as an ordinal.
-/// - `priority`: The [zenoh::core::Priority] configuration as an ordinal.
-/// - `is_express`: The express config of the publisher (see [zenoh::prelude::QoSBuilderTrait]).
-///
-/// Returns:
-/// - A [Result] containing a raw pointer to the declared Zenoh publisher ([Publisher]) in case of success,
-///   or an [Error] variant in case of failure.
-///
-/// Safety:
-/// - The returned raw pointer should be stored appropriately and later freed using [Java_io_zenoh_jni_JNIPublisher_freePtrViaJNI].
-///
-pub(crate) unsafe fn declare_publisher(
-    env: &mut JNIEnv,
-    key_expr_ptr: *const KeyExpr<'static>,
-    key_expr_str: JString,
-    session_ptr: *const Session,
-    congestion_control: jint,
-    priority: jint,
-    is_express: jboolean,
-) -> Result<*const Publisher<'static>> {
-    let session = Arc::from_raw(session_ptr);
-    let key_expr = process_kotlin_key_expr(env, &key_expr_str, key_expr_ptr)?;
-    let congestion_control = decode_congestion_control(congestion_control)?;
-    let priority = decode_priority(priority)?;
-    let result = session
-        .declare_publisher(key_expr)
-        .congestion_control(congestion_control)
-        .priority(priority)
-        .express(is_express != 0)
-        .wait();
-    std::mem::forget(session);
-    match result {
-        Ok(publisher) => Ok(Arc::into_raw(Arc::new(publisher))),
-        Err(err) => Err(Error::Session(err.to_string())),
-    }
-}
-
-/// Modifies the congestion control policy of a running Publisher through JNI.
-///
-/// This function is meant to be called from Java/Kotlin code through JNI.
-///
-/// Parameters:
-/// - `env`: The JNI environment.
-/// - `_class`: The Publisher class (unused but required).
-/// - `congestion_control`: The [zenoh::publisher::CongestionControl] value to be set.
-/// - `ptr`: Pointer to the publisher.
-///
-/// Safety:
-/// - This function is maked as unsafe due to raw pointer manipulation.
-/// - This function is NOT thread safe; if there were to be multiple threads calling this function
-///   concurrently while providing the same Publisher pointer, the result will be non deterministic.
-///
-/// Throws:
-/// - An exception in case the congestion control fails to be decoded.
-///
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_setCongestionControlViaJNI(
-    env: &mut JNIEnv,
-    _class: JClass,
-    congestion_control: jint,
-    ptr: *const Publisher<'static>,
-) {
-    let congestion_control = match decode_congestion_control(congestion_control) {
-        Ok(congestion_control) => congestion_control,
-        Err(err) => {
-            _ = err.throw_on_jvm(env);
-            return;
-        }
-    };
-    tracing::debug!("Setting publisher congestion control with '{congestion_control:?}'.");
-    unsafe {
-        let mut publisher = core::ptr::read(ptr);
-        publisher.set_congestion_control(congestion_control);
-        core::ptr::write(ptr as *mut _, ())
-    }
-}
-
-/// Modifies the priority policy of a running Publisher through JNI.
-///
-/// This function is meant to be called from Java/Kotlin code through JNI.
-///
-/// Parameters:
-/// - `env`: The JNI environment.
-/// - `_class`: The Publisher class (unused but required).
-/// - `priority`: The [zenoh::core::Priority] value to be set.
-/// - `ptr`: Pointer to the publisher.
-///
-/// Safety:
-/// - This function is maked as unsafe due to raw pointer manipulation.
-/// - This function is NOT thread safe; if there were to be multiple threads calling this function
-///   concurrently while providing the same Publisher pointer, the result will be non deterministic.
-///
-/// Throws:
-/// - An exception in case the priority fails to be decoded.
-///
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_setPriorityViaJNI(
-    env: &mut JNIEnv,
-    _class: JClass,
-    priority: jint,
-    ptr: *const Publisher<'static>,
-) {
-    let priority = match decode_priority(priority) {
-        Ok(priority) => priority,
-        Err(err) => {
-            _ = err.throw_on_jvm(env);
-            return;
-        }
-    };
-    tracing::debug!("Setting publisher priority with '{priority:?}'.");
-    unsafe {
-        let mut publisher = core::ptr::read(ptr);
-        publisher.set_priority(priority);
-        core::ptr::write(ptr as *mut _, ());
-    }
 }
 
 /// Performs a DELETE operation via JNI using the specified Zenoh publisher.

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -220,9 +220,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_closeSessionViaJNI(
 /// - `key_expr_str`: String representation of the [KeyExpr] to be used for the publisher.
 ///     It is only considered when the key_expr_ptr parameter is null, meaning the function is
 ///     receiving a key expression that was not declared.
-/// - `session_ptr`: The raw pointer to the Zenoh [Session] from which to declare the publisher.
-/// - `congestion_control`: The [CongestionControl] mechanism specified as an ordinal.
-/// - `priority`: The [Priority] mechanism specified as an ordinal.
+/// - `session_ptr`: Raw pointer to the Zenoh [Session] to be used for the publisher.
+/// - `congestion_control`: The [zenoh::publisher::CongestionControl] configuration as an ordinal.
+/// - `priority`: The [zenoh::core::Priority] configuration as an ordinal.
+/// - `is_express`: The express config of the publisher (see [zenoh::prelude::QoSBuilderTrait]).
 ///
 /// Returns:
 /// - A raw pointer to the declared Zenoh publisher or null in case of failure.
@@ -245,6 +246,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declarePublisherViaJNI(
     session_ptr: *const Session,
     congestion_control: jint,
     priority: jint,
+    is_express: jboolean,
 ) -> *const Publisher<'static> {
     let result = declare_publisher(
         &mut env,
@@ -253,6 +255,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declarePublisherViaJNI(
         session_ptr,
         congestion_control,
         priority,
+        is_express,
     );
     match result {
         Ok(ptr) => ptr,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -18,6 +18,7 @@ import io.zenoh.exceptions.SessionException
 import io.zenoh.handlers.Callback
 import io.zenoh.jni.JNISession
 import io.zenoh.keyexpr.KeyExpr
+import io.zenoh.prelude.QoS
 import io.zenoh.publication.Delete
 import io.zenoh.publication.Publisher
 import io.zenoh.publication.Put
@@ -380,9 +381,9 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         return jniSession != null
     }
 
-    internal fun resolvePublisher(builder: Publisher.Builder): Result<Publisher> {
+    internal fun resolvePublisher(keyExpr: KeyExpr, qos: QoS): Result<Publisher> {
         return jniSession?.run {
-            declarePublisher(builder)
+            declarePublisher(keyExpr, qos)
         } ?: Result.failure(sessionClosedException)
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
@@ -51,7 +51,6 @@ internal class JNIPublisher(private val ptr: Long) {
         freePtrViaJNI(ptr)
     }
 
-    /** Puts through the native Publisher. */
     @Throws(Exception::class)
     private external fun putViaJNI(
         valuePayload: ByteArray, encodingId: Int, encodingSchema: String?, attachment: ByteArray?, ptr: Long
@@ -60,7 +59,6 @@ internal class JNIPublisher(private val ptr: Long) {
     @Throws(Exception::class)
     private external fun deleteViaJNI(attachment: ByteArray?, ptr: Long)
 
-    /** Frees the underlying native Publisher. */
     private external fun freePtrViaJNI(ptr: Long)
 
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIPublisher.kt
@@ -14,9 +14,6 @@
 
 package io.zenoh.jni
 
-import io.zenoh.*
-import io.zenoh.prelude.CongestionControl
-import io.zenoh.prelude.Priority
 import io.zenoh.value.Value
 
 /**
@@ -53,51 +50,6 @@ internal class JNIPublisher(private val ptr: Long) {
     fun close() {
         freePtrViaJNI(ptr)
     }
-
-    /**
-     * Set the congestion control policy of the publisher.
-     *
-     * This function is not thread safe.
-     *
-     * @param congestionControl: The [CongestionControl] policy.
-     * @return A [Result] with the status of the operation.
-     */
-    fun setCongestionControl(congestionControl: CongestionControl): Result<Unit> = runCatching {
-        setCongestionControlViaJNI(congestionControl.value, ptr)
-    }
-
-    /**
-     * Set the priority policy of the publisher.
-     *
-     * This function is not thread safe.
-     *
-     * @param priority: The [Priority] policy.
-     * @return A [Result] with the status of the operation.
-     */
-    fun setPriority(priority: Priority): Result<Unit> = runCatching {
-        setPriorityViaJNI(priority.value, ptr)
-    }
-
-    /**
-     * Set the congestion control policy of the publisher through JNI.
-     *
-     * This function is NOT thread safe.
-     *
-     * @param congestionControl The congestion control policy.
-     * @param ptr Pointer to the publisher.
-     */
-    private external fun setCongestionControlViaJNI(congestionControl: Int, ptr: Long)
-
-    /**
-     * Set the priority policy of the publisher through JNI.
-     *
-     * This function is NOT thread safe.
-     *
-     * @param priority The priority policy.
-     * @param ptr Pointer to the publisher.
-     */
-    private external fun setPriorityViaJNI(priority: Int, ptr: Long)
-
 
     /** Puts through the native Publisher. */
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -58,19 +58,19 @@ internal class JNISession {
         closeSessionViaJNI(sessionPtr.get())
     }
 
-    fun declarePublisher(builder: Publisher.Builder): Result<Publisher> = runCatching {
+    fun declarePublisher(keyExpr: KeyExpr, qos: QoS): Result<Publisher> = runCatching {
         val publisherRawPtr = declarePublisherViaJNI(
-            builder.keyExpr.jniKeyExpr?.ptr ?: 0,
-            builder.keyExpr.keyExpr,
+            keyExpr.jniKeyExpr?.ptr ?: 0,
+            keyExpr.keyExpr,
             sessionPtr.get(),
-            builder.congestionControl.value,
-            builder.priority.value,
+            qos.congestionControl.value,
+            qos.priority.value,
+            qos.express
         )
         Publisher(
-            builder.keyExpr,
+            keyExpr,
+            qos,
             JNIPublisher(publisherRawPtr),
-            builder.congestionControl,
-            builder.priority,
         )
     }
 
@@ -254,7 +254,8 @@ internal class JNISession {
         keyExprString: String,
         sessionPtr: Long,
         congestionControl: Int,
-        priority: Int
+        priority: Int,
+        express: Boolean
     ): Long
 
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
@@ -91,34 +91,9 @@ class Publisher internal constructor(
         return qos.congestionControl()
     }
 
-    /**
-     * Set the congestion control policy of the publisher.
-     *
-     * This function is not thread safe.
-     *
-     * @param congestionControl: The [CongestionControl] policy.
-     */
-    fun setCongestionControl(congestionControl: CongestionControl) {
-        jniPublisher?.setCongestionControl(congestionControl)?.onSuccess {
-            this@Publisher.qos = QoS(this.qos.express, congestionControl, this.qos.priority) }
-    }
-
     /** Get priority policy. */
     fun getPriority(): Priority {
         return qos.priority()
-    }
-
-    /**
-     * Set the priority policy of the publisher.
-     *
-     * This function is not thread safe.
-     *
-     * @param priority: The [Priority] policy.
-     */
-    fun setPriority(priority: Priority) {
-        jniPublisher?.setPriority(priority)?.onSuccess {
-            this@Publisher.qos = QoS(this.qos.express, this.qos.congestionControl, priority)
-        }
     }
 
     override fun isValid(): Boolean {


### PR DESCRIPTION
* Removing functions that allowed users to dynamically set the QoS parameters after [Zenoh PR #1124](https://github.com/eclipse-zenoh/zenoh/pull/1124), those being `Publisher.setCongestionControl(cc)` and `Publisher.setPriority(priority)`.
* Allowing users to specify the `express` QoS config parameter while building the publisher.
* Some refactoring on the zenoh-jni code regarding the publisher.