### PR TITLE
fix: wrong syntax in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
   # Publish snapshot packages. These jobs will only be triggered when the CI is executed on main.
   publish_jvm_snapshot_package:
     name: Publish JVM snapshot package
-    if: contains(['refs/heads/main', 'refs/heads/dev/1.0.0'], github.ref)
+    if: contains(fromJSON('["refs/heads/main", "refs/heads/dev/1.0.0"]'), github.ref)
     needs: ci
     uses: ./.github/workflows/publish-jvm.yml
     permissions:
@@ -94,7 +94,7 @@ jobs:
 
   publish_android_snapshot_package:
     name: Publish Android snapshot package
-    if: contains(['refs/heads/main', 'refs/heads/dev/1.0.0'], github.ref)
+    if: contains(fromJSON('["refs/heads/main", "refs/heads/dev/1.0.0"]'), github.ref)
     needs: ci
     uses: ./.github/workflows/publish-android.yml
     permissions:


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/9834331303