### PR TITLE
fix: Update gradle actions to newer versions

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -58,7 +58,7 @@ jobs:
           gradle wrapper
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set pub mode env var
         # Note: This step is intended to allow publishing snapshot packages.

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -71,8 +71,6 @@ jobs:
           fi
 
       - name: Gradle Publish Android Package
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publishAndroidReleasePublicationToGithubPackagesRepository -Pandroid=true ${{ env.PUB_MODE }}
+        run: ./gradlew publishAndroidReleasePublicationToGithubPackagesRepository -Pandroid=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -33,7 +33,7 @@ jobs:
           link-to-sdk: true
 
       - name: Build doc
-        run: gradle dokkaHtml
+        run: gradle -Pandroid dokkaHtml
 
       - name: Deploy doc
         if: ${{ inputs.live-run || false }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -170,8 +170,6 @@ jobs:
           fi
 
       - name: Gradle Publish JVM Package
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publishJvmPublicationToGithubPackagesRepository -PgithubPublish=true ${{ env.PUB_MODE }}
+        run: ./gradlew publishJvmPublicationToGithubPackagesRepository -PgithubPublish=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -157,7 +157,7 @@ jobs:
           gradle wrapper
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set pub mode env var
         # Note: This step is intended to allow publishing snapshot packages.

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -117,7 +117,6 @@ tasks.withType<Test> {
 tasks.whenObjectAdded {
     if ((this.name == "mergeDebugJniLibFolders" || this.name == "mergeReleaseJniLibFolders")) {
         this.dependsOn("cargoBuild")
-        this.inputs.dir(layout.buildDirectory.dir("rustJniLibs/android"))
     }
 }
 

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -117,7 +117,7 @@ tasks.withType<Test> {
 tasks.whenObjectAdded {
     if ((this.name == "mergeDebugJniLibFolders" || this.name == "mergeReleaseJniLibFolders")) {
         this.dependsOn("cargoBuild")
-        this.inputs.dir(buildDir.resolve("rustJniLibs/android"))
+        this.inputs.dir(layout.buildDirectory.dir("rustJniLibs/android"))
     }
 }
 


### PR DESCRIPTION
- Update `buildDir()` usage according to https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir
- Update gradle wrapper to use new action https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation
- Update gradle actions to not use arguments: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated