### PR TITLE
Fix JVM crash when finalizing a session that wasn't properly initialized

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -50,7 +50,7 @@ import java.time.Duration
  */
 class Session private constructor(private val config: Config) : AutoCloseable {
 
-    private var jniSession: JNISession? = JNISession()
+    private var jniSession: JNISession? = null
 
     companion object {
 
@@ -439,7 +439,10 @@ class Session private constructor(private val config: Config) : AutoCloseable {
 
     /** Launches the session through the jni session, returning the [Session] on success. */
     private fun launch(): Result<Session> = runCatching {
-        return jniSession!!.open(config).map { this@Session }
+        jniSession = JNISession()
+        return jniSession!!.open(config)
+            .map { this@Session }
+            .onFailure { jniSession = null }
     }
 }
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionTest.kt
@@ -19,6 +19,7 @@ import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.keyexpr.intoKeyExpr
 import io.zenoh.sample.Sample
 import kotlinx.coroutines.runBlocking
+import java.nio.file.Path
 import kotlin.test.*
 
 class SessionTest {
@@ -40,6 +41,12 @@ class SessionTest {
         assertTrue(session.isOpen())
         session.close()
         assertFalse(session.isOpen())
+    }
+
+    @Test
+    fun sessionOpeningFailure() {
+        val invalidConfig = Config.from(Path.of("invalid"))
+        assertFailsWith<SessionException> { Session.open(invalidConfig).getOrThrow() }
     }
 
     @Test


### PR DESCRIPTION
To reproduce:

```
    @Test
    fun sessionOpeningFailure() = repeat(100) {
        val invalidConfig = Config.from(Path.of("invalid"))
        assertFailsWith<SessionException> { Session.open(invalidConfig).getOrThrow() }
        System.gc()
    }
```