### PR TITLE
alignment(reply): aligning the Reply logic with the Rust api.

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Reply.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Reply.kt
@@ -16,38 +16,25 @@ package io.zenoh.query
 
 import io.zenoh.ZenohType
 import io.zenoh.sample.Sample
-import io.zenoh.keyexpr.KeyExpr
-import io.zenoh.prelude.Encoding
-import io.zenoh.prelude.QoS
-import io.zenoh.protocol.ZBytes
 import io.zenoh.protocol.ZenohID
 import io.zenoh.queryable.Query
-import org.apache.commons.net.ntp.TimeStamp
 
 /**
  * Class to represent a Zenoh Reply to a get query and to a remote [Query].
  *
- * A reply can be either successful ([Success]), an error ([Error]) or a delete request ([Delete]), both having different
- * information.
- * // TODO: fix comment and example after modifying the replies.
- *
  * Example:
+ *
  * ```kotlin
- * Session.open(config).onSuccess { session ->
- *     session.use {
- *         key.intoKeyExpr().onSuccess { keyExpr ->
- *             session.declareQueryable(keyExpr, Channel()).onSuccess { queryable ->
- *                 runBlocking {
- *                     for (query in queryable.receiver) {
- *                         val valueInfo = query.value?.let { value -> " with value '$value'" } ?: ""
- *                         println(">> [Queryable] Received Query '${query.selector}' $valueInfo")
- *                         query.replySuccess(
- *                             keyExpr,
- *                             payload = "Example payload".into(),
- *                             timestamp = TimeStamp.getCurrentTime()
- *                         ).getOrThrow()
- *                     }
+ * session.get(selector, channel = Channel()).onSuccess { channelReceiver ->
+ *     runBlocking {
+ *         for (reply in channelReceiver) {
+ *             reply.result.onSuccess { sample ->
+ *                 when (sample.kind) {
+ *                     SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
+ *                     SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
  *                 }
+ *             }.onFailure { error ->
+ *                 println("Received (ERROR: '${error.message}')")
  *             }
  *         }
  *     }
@@ -57,57 +44,4 @@ import org.apache.commons.net.ntp.TimeStamp
  * @property replierId: unique ID identifying the replier, may be null in case the network cannot provide it
  *   (@see https://github.com/eclipse-zenoh/zenoh/issues/709#issuecomment-2202763630).
  */
-sealed class Reply private constructor(open val replierId: ZenohID?) : ZenohType {
-
-    /**
-     * A successful [Reply].
-     *
-     * @property sample The [Sample] of the reply.
-     * @constructor Internal constructor, since replies are only meant to be generated upon receiving a remote reply
-     * or by calling [Query.reply] to reply to the specified [Query].
-     *
-     * @param replierId The replierId of the remotely generated reply.
-     */
-    data class Success internal constructor(override val replierId: ZenohID? = null, val sample: Sample) : Reply(replierId) {
-
-        override fun toString(): String {
-            return "Success(sample=$sample)"
-        }
-    }
-
-    /**
-     * An Error reply.
-     *
-     * @property replierId Unique ID identifying the replier.
-     * @property error Error message.
-     * @property encoding [Encoding] of the error message.
-     */
-    data class Error internal constructor(override val replierId: ZenohID? = null, val error: ZBytes, val encoding: Encoding) : Reply(replierId) {
-
-        override fun toString(): String {
-            return "Error(error=$error)"
-        }
-    }
-
-    /**
-     * A Delete reply.
-     *
-     * @property replierId Unique ID identifying the replier.
-     * @property keyExpr Key expression to reply to. This parameter must not be necessarily the same
-     * as the key expression from the Query, however it must intersect with the query key.
-     * @property attachment Optional attachment for the delete reply.
-     * @property qos QoS for the reply.
-     */
-    data class Delete internal constructor(
-        override val replierId: ZenohID? = null,
-        val keyExpr: KeyExpr,
-        val timestamp: TimeStamp?,
-        val attachment: ZBytes?,
-        val qos: QoS
-    ) : Reply(replierId) {
-
-        override fun toString(): String {
-            return "Delete(keyexpr=$keyExpr)"
-        }
-    }
-}
+data class Reply (val replierId: ZenohID?, val result: Result<Sample>) : ZenohType

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/ReplyError.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/ReplyError.kt
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.query
+
+import io.zenoh.prelude.Encoding
+import io.zenoh.protocol.ZBytes
+
+/**
+ * Reply error class.
+ *
+ * When receiving an error reply while performing a get operation, this is the error type returned:
+ * ```kotlin
+ * session.get(selector, callback = { reply ->
+ *     reply.result.onSuccess { sample ->
+ *         // ...
+ *     }.onFailure { error ->
+ *         error as ReplyError
+ *         println("Received (ERROR: '${error.payload}' with encoding '${error.encoding}'.)")
+ *         // ...
+ *     }
+ * })
+ * ```
+ *
+ * This class is useful in case you need to apply different logic based on the encoding of the error or
+ * need to deserialize the [payload] value into something else other than a string.
+ *
+ * Otherwise, the error payload can be obtained as a string under the [Throwable.message] parameter:
+ * ```kotlin
+ * session.get(selector, callback = { reply ->
+ *     reply.result.onSuccess { sample ->
+ *         // ...
+ *     }.onFailure { error ->
+ *         println("Received (ERROR: '${error.message}')")
+ *         // ...
+ *     }
+ * })
+ * ```
+ */
+data class ReplyError(val payload: ZBytes?, val encoding: Encoding?) : Throwable(message = payload.toString())

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/GetTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/GetTest.kt
@@ -61,8 +61,8 @@ class GetTest {
             reply = it
         }, timeout = Duration.ofMillis(1000))
 
-        assertTrue(reply is Reply.Success)
-        val sample = (reply as Reply.Success).sample
+        assertNotNull(reply)
+        val sample = reply!!.result.getOrThrow()
         assertEquals(payload, sample.payload)
         assertEquals(kind, sample.kind)
         assertEquals(selector.keyExpr, sample.keyExpr)
@@ -74,8 +74,7 @@ class GetTest {
         val receiver: ArrayList<Reply> = session.get(selector, handler = TestHandler(), timeout = Duration.ofMillis(1000)).getOrThrow()
 
         for (reply in receiver) {
-            reply as Reply.Success
-            val receivedSample = reply.sample
+            val receivedSample = reply.result.getOrThrow()
             assertEquals(payload, receivedSample.payload)
             assertEquals(SampleKind.PUT, receivedSample.kind)
             assertEquals(timestamp, receivedSample.timestamp)

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/UserAttachmentTest.kt
@@ -50,7 +50,8 @@ class UserAttachmentTest {
     @Test
     fun putWithAttachmentTest() {
         var receivedSample: Sample? = null
-        val subscriber = session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
+        val subscriber =
+            session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
         session.put(keyExpr, payload, attachment = attachmentZBytes)
 
         subscriber.close()
@@ -84,7 +85,8 @@ class UserAttachmentTest {
     fun publisherPutWithoutAttachmentTest() {
         var receivedSample: Sample? = null
         val publisher = session.declarePublisher(keyExpr).getOrThrow()
-        val subscriber = session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
+        val subscriber =
+            session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
 
         publisher.put("test")
 
@@ -100,7 +102,8 @@ class UserAttachmentTest {
     fun publisherDeleteWithAttachmentTest() {
         var receivedSample: Sample? = null
         val publisher = session.declarePublisher(keyExpr).getOrThrow()
-        val subscriber = session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
+        val subscriber =
+            session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
 
         publisher.delete(attachment = attachmentZBytes)
 
@@ -117,7 +120,8 @@ class UserAttachmentTest {
     fun publisherDeleteWithoutAttachmentTest() {
         var receivedSample: Sample? = null
         val publisher = session.declarePublisher(keyExpr).getOrThrow()
-        val subscriber = session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
+        val subscriber =
+            session.declareSubscriber(keyExpr, callback = { sample -> receivedSample = sample }).getOrThrow()
 
         publisher.delete()
 
@@ -137,7 +141,12 @@ class UserAttachmentTest {
             query.replySuccess(keyExpr, payload)
         }).getOrThrow()
 
-        session.get(keyExpr.intoSelector(), callback = {}, attachment = attachmentZBytes, timeout = Duration.ofMillis(1000)).getOrThrow()
+        session.get(
+            keyExpr.intoSelector(),
+            callback = {},
+            attachment = attachmentZBytes,
+            timeout = Duration.ofMillis(1000)
+        ).getOrThrow()
 
         queryable.close()
 
@@ -154,17 +163,14 @@ class UserAttachmentTest {
         }).getOrThrow()
 
         session.get(keyExpr.intoSelector(), callback = {
-            if (it is Reply.Success) {
-                reply = it
-            }
+            reply = it
         }, timeout = Duration.ofMillis(1000)).getOrThrow()
 
         queryable.close()
 
-        assertNotNull(reply) {
-            val receivedAttachment = (it as Reply.Success).sample.attachment!!
-            assertEquals(attachment, receivedAttachment.toString())
-        }
+        assertNotNull(reply)
+        val receivedAttachment = reply!!.result.getOrThrow().attachment!!
+        assertEquals(attachment, receivedAttachment.toString())
     }
 
     @Test
@@ -180,9 +186,8 @@ class UserAttachmentTest {
 
         queryable.close()
 
-        assertNotNull(reply) {
-            assertTrue(it is Reply.Success)
-            assertNull(it.sample.attachment)
-        }
+        assertNotNull(reply)
+        assertTrue(reply!!.result.isSuccess)
+        assertNull(reply!!.result.getOrThrow().attachment)
     }
 }


### PR DESCRIPTION
Replacing the reply logic from:
```kotlin
for (reply in channelReceiver) {
    when (reply) {
        is Reply.Success -> println("Received ('${reply.sample.keyExpr}': '${reply.sample.payload}')")
        is Reply.Error -> println("Received (ERROR: '${reply.error}')")
        is Reply.Delete -> println("Received (DELETE '${reply.keyExpr}')")
    }
}
```

to

```kotlin
 for (reply in channelReceiver) {
    reply.result.onSuccess { sample ->
        when (sample.kind) {
            SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
            SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
        }
    }.onFailure { error ->
        println("Received (ERROR: '${error.message}')")
    }
}
```

On Kotlin, the type of the error param from `onFailure` is always `Throwable`. With the changes introduced here, It can be downcasted into a `ReplyError` which allow accessing the `payload` as a ZBytes and the encoding.

For instance:
```kotlin
 for (reply in channelReceiver) {
    reply.result.onSuccess { sample ->
        when (sample.kind) {
            SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
            SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
        }
    }.onFailure { error ->
         error as ReplyError       
         println("Received (ERROR: '${error.payload}' with encoding '${error.encoding}')")
    }
}
```

