### PR TITLE
Use default ConsolidationMode in Session.get

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -687,7 +687,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         attachment: ZBytes? = null,
         timeout: Duration = Duration.ofMillis(10000),
         target: QueryTarget = QueryTarget.BEST_MATCHING,
-        consolidation: ConsolidationMode = ConsolidationMode.NONE,
+        consolidation: ConsolidationMode = ConsolidationMode.default(),
         onClose: (() -> Unit)? = null
     ): Result<Channel<Reply>> {
         val channelHandler = ChannelHandler(channel)


### PR DESCRIPTION
This PR aligns zenoh-kotlin default ConsolidationMode of `Session.get` with the other bindings.