### PR TITLE
api(selector): alignment of the selector api

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -34,6 +34,7 @@ import io.zenoh.query.*
 import io.zenoh.queryable.Query
 import io.zenoh.queryable.Queryable
 import io.zenoh.sample.Sample
+import io.zenoh.selector.Parameters
 import io.zenoh.selector.Selector
 import io.zenoh.subscriber.Reliability
 import io.zenoh.subscriber.Subscriber
@@ -111,7 +112,7 @@ internal class JNISession {
                 val selector = if (selectorParams.isEmpty()) {
                     Selector(keyExpr2)
                 } else {
-                    Selector(keyExpr2, selectorParams)
+                    Selector(keyExpr2, Parameters.from(selectorParams).getOrThrow())
                 }
                 val query = Query(
                     keyExpr2,
@@ -185,7 +186,7 @@ internal class JNISession {
         getViaJNI(
             selector.keyExpr.jniKeyExpr?.ptr ?: 0,
             selector.keyExpr.keyExpr,
-            selector.parameters,
+            selector.parameters.toString(),
             sessionPtr.get(),
             getCallback,
             onClose,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/selector/IntoSelector.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/selector/IntoSelector.kt
@@ -19,11 +19,12 @@ import io.zenoh.keyexpr.KeyExpr
 
 fun String.intoSelector(): Result<Selector> = runCatching {
     if (this.isEmpty()) {
-        return Result.failure(KeyExprException("Attempting to create a KeyExpr from an empty string."))
+        throw KeyExprException("Attempting to create a KeyExpr from an empty string.")
     }
     val result = this.split('?', limit = 2)
     val keyExpr = KeyExpr.autocanonize(result[0]).getOrThrow()
-    val params = if (result.size == 2) result[1] else ""
-    return Result.success(Selector(keyExpr, params))
+    val params = if (result.size == 2) Parameters.from(result[1]).getOrThrow() else null
+
+    Selector(keyExpr, params)
 }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/selector/Parameters.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/selector/Parameters.kt
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.selector
+
+import java.net.URLDecoder
+
+/**
+ * Parameters of the [Selector].
+ *
+ * When in string form, the `parameters` should be encoded like the query section of a URL:
+ *  - parameters are separated by `;`,
+ *  - the parameter name and value are separated by the first `=`,
+ *  - in the absence of `=`, the parameter value is considered to be the empty string,
+ *  - both name and value should use percent-encoding to escape characters,
+ *  - defining a value for the same parameter name twice is considered undefined behavior and an
+ *    error result is returned.
+ *
+ * @see Selector
+ */
+data class Parameters internal constructor(private val params: MutableMap<String, String>) : IntoParameters {
+
+    companion object {
+
+        private const val LIST_SEPARATOR = ";"
+        private const val FIELD_SEPARATOR = "="
+        private const val VALUE_SEPARATOR = "|"
+
+        /**
+         * Creates an empty Parameters.
+         */
+        fun empty() = Parameters(mutableMapOf())
+
+        /**
+         * Creates a [Parameters] instance from the provided map.
+         */
+        fun from(params: Map<String, String>): Parameters = Parameters(params.toMutableMap())
+
+        /**
+         * Attempts to create a [Parameters] from a string.
+         *
+         * When in string form, the `parameters` should be encoded like the query section of a URL:
+         *  - parameters are separated by `;`,
+         *  - the parameter name and value are separated by the first `=`,
+         *  - in the absence of `=`, the parameter value is considered to be the empty string,
+         *  - both name and value should use percent-encoding to escape characters,
+         *  - defining a value for the same parameter name twice is considered undefined behavior and an
+         *    error result is returned.
+         */
+        fun from(params: String): Result<Parameters> = runCatching {
+            if (params.isBlank()) {
+                return@runCatching Parameters(mutableMapOf())
+            }
+            params.split(LIST_SEPARATOR).fold(mutableMapOf<String, String>()) { parametersMap, parameter ->
+                val (key, value) = parameter.split(FIELD_SEPARATOR).let { it[0] to it.getOrNull(1) }
+                require(!parametersMap.containsKey(key)) { "Duplicated parameter `$key` detected." }
+                parametersMap[key] = value?.let { URLDecoder.decode(it, Charsets.UTF_8.name()) } ?: ""
+                parametersMap
+            }.let { Parameters(it) }
+        }
+    }
+
+    override fun toString(): String =
+        params.entries.joinToString(LIST_SEPARATOR) { "${it.key}$FIELD_SEPARATOR${it.value}" }
+
+    override fun into(): Parameters = this
+
+    /**
+     * Returns empty if no parameters were provided.
+     */
+    fun isEmpty(): Boolean = params.isEmpty()
+
+    /**
+     * Returns true if the [key] is contained.
+     */
+    fun containsKey(key: String): Boolean = params.containsKey(key)
+
+    /**
+     * Returns the value of the [key] if present.
+     */
+    fun get(key: String): String? = params[key]
+
+    /**
+     * Returns the value of the [key] if present, or if not, the [default] value provided.
+     */
+    fun getOrDefault(key: String, default: String): String = params.getOrDefault(key, default)
+
+    /**
+     * Returns the values of the [key] if present.
+     *
+     * Example:
+     * ```kotlin
+     * val parameters = Parameters.from("a=1;b=2;c=1|2|3").getOrThrow()
+     * assertEquals(listOf("1", "2", "3"), parameters.values("c"))
+     * ```
+     */
+    fun values(key: String): List<String>? = params[key]?.split(VALUE_SEPARATOR)
+
+    /**
+     * Inserts the key-value pair into the parameters, returning the old value
+     * in case of it being already present.
+     */
+    fun insert(key: String, value: String): String? = params.put(key, value)
+
+    /**
+     * Removes the [key] parameter, returning its value.
+     */
+    fun remove(key: String): String? = params.remove(key)
+
+    /**
+     * Extends the parameters with the [parameters] provided, overwriting
+     * any conflicting params.
+     */
+    fun extend(parameters: IntoParameters) {
+        params.putAll(parameters.into().params)
+    }
+
+    /**
+     * Extends the parameters with the [parameters] provided, overwriting
+     * any conflicting params.
+     */
+    fun extend(parameters: Map<String, String>) {
+        params.putAll(parameters)
+    }
+
+    /**
+     * Returns a map with the key value pairs of the parameters.
+     */
+    fun toMap(): Map<String, String> = params
+}
+
+interface IntoParameters {
+    fun into(): Parameters
+}

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/GetTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/GetTest.kt
@@ -19,6 +19,7 @@ import io.zenoh.prelude.SampleKind
 import io.zenoh.protocol.into
 import io.zenoh.query.Reply
 import io.zenoh.queryable.Queryable
+import io.zenoh.selector.Parameters
 import io.zenoh.selector.Selector
 import io.zenoh.selector.intoSelector
 import org.apache.commons.net.ntp.TimeStamp
@@ -83,22 +84,18 @@ class GetTest {
 
     @Test
     fun getWithSelectorParamsTest() {
-        var receivedParams: String? = null
-        var receivedParamsMap : Map<String, String>? = null
+        var receivedParams: Parameters? = null
         val queryable = session.declareQueryable(selector.keyExpr, callback = { query ->
             receivedParams = query.parameters
-            receivedParamsMap = query.selector.parametersStringMap()?.getOrThrow()
         }).getOrThrow()
 
-        val params = "arg1=val1&arg2=val2&arg3"
-        val paramsMap = mapOf("arg1" to "val1", "arg2" to "val2", "arg3" to "")
+        val params = Parameters.from("arg1=val1&arg2=val2&arg3").getOrThrow()
         val selectorWithParams = Selector(selector.keyExpr, params)
         session.get(selectorWithParams, callback = {}, timeout = Duration.ofMillis(1000))
 
         queryable.close()
 
         assertEquals(params, receivedParams)
-        assertEquals(paramsMap, receivedParamsMap)
     }
 }
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ParametersTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ParametersTest.kt
@@ -1,0 +1,127 @@
+package io.zenoh
+
+import io.zenoh.selector.Parameters
+import org.junit.jupiter.api.Assertions.assertFalse
+import kotlin.test.*
+
+class ParametersTest {
+
+    @Test
+    fun `should create empty Parameters from empty string`() {
+        val result = Parameters.from("")
+        val emptyParams = result.getOrThrow()
+
+        assertTrue(result.isSuccess)
+        assertTrue(emptyParams.isEmpty())
+    }
+
+    @Test
+    fun `should parse Parameters from formatted string`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertEquals("1", parameters.get("a"))
+        assertEquals("2", parameters.get("b"))
+        assertEquals("3|4|5", parameters.get("c"))
+        assertEquals("6", parameters.get("d"))
+    }
+
+    @Test
+    fun `should return list of values split by separator`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertEquals(listOf("3", "4", "5"), parameters.values("c"))
+    }
+
+    @Test
+    fun `contains key test`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertTrue { parameters.containsKey("a") }
+        assertFalse { parameters.containsKey("e") }
+    }
+
+    @Test
+    fun `get test`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertEquals("1", parameters.get("a"))
+        assertEquals("2", parameters.get("b"))
+        assertEquals("3|4|5", parameters.get("c"))
+        assertEquals("6", parameters.get("d"))
+    }
+
+    @Test
+    fun `getOrDefault test`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertEquals("1", parameters.get("a"))
+        assertEquals("None", parameters.getOrDefault("e", "None"))
+    }
+
+    @Test
+    fun `toMap test`() {
+        val parameters =  Parameters.from("a=1;b=2;c=3|4|5;d=6").getOrThrow()
+
+        assertEquals(mapOf("a" to "1", "b" to "2", "c" to "3|4|5", "d" to "6"), parameters.toMap())
+    }
+
+    @Test
+    fun `insert should return previously contained value`() {
+        val parameters = Parameters.from("a=1").getOrThrow()
+        val oldValue = parameters.insert("a", "3")
+        assertEquals("1", oldValue)
+    }
+
+    @Test
+    fun `insert should return null if not already present`() {
+        val parameters = Parameters.empty()
+        val oldValue = parameters.insert("a", "1")
+        assertNull(oldValue)
+    }
+
+    @Test
+    fun `remove should return old value if present`() {
+        val parameters = Parameters.from("a=1").getOrThrow()
+        val oldValue = parameters.remove("a")
+        assertEquals("1", oldValue)
+    }
+
+    @Test
+    fun `remove should return null if not already present`() {
+        val parameters = Parameters.empty()
+        val oldValue = parameters.remove("a")
+        assertNull(oldValue)
+    }
+
+    @Test
+    fun `extend test`() {
+        val parameters = Parameters.from("a=1;b=2").getOrThrow()
+        parameters.extend(Parameters.from("c=3;d=4").getOrThrow())
+
+        assertEquals(Parameters.from("a=1;b=2;c=3;d=4").getOrThrow(), parameters)
+
+        parameters.extend(mapOf("e" to "5"))
+        assertEquals(Parameters.from("a=1;b=2;c=3;d=4;e=5").getOrThrow(), parameters)
+    }
+
+    @Test
+    fun `extend overwrites conflicting keys test`() {
+        val parameters = Parameters.from("a=1;b=2").getOrThrow()
+        parameters.extend(Parameters.from("b=3;d=4").getOrThrow())
+
+        assertEquals(Parameters.from("a=1;b=3;d=4").getOrThrow(), parameters)
+    }
+
+    @Test
+    fun `to string test`() {
+        val parameters = Parameters.from(mapOf("a" to "1", "b" to "2", "c" to "1|2|3", "d" to "4"))
+        assertEquals("a=1;b=2;c=1|2|3;d=4", parameters.toString())
+    }
+
+    @Test
+    fun `empty Parameters to string test`() {
+        val parameters = Parameters.empty()
+        assertEquals("", parameters.toString())
+    }
+
+}

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SelectorTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SelectorTest.kt
@@ -3,6 +3,7 @@ package io.zenoh
 import io.zenoh.exceptions.KeyExprException
 import io.zenoh.selector.Selector
 import io.zenoh.selector.intoSelector
+import org.junit.jupiter.api.Assertions.assertNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -10,17 +11,28 @@ import kotlin.test.assertFailsWith
 class SelectorTest {
 
     @Test
-    fun selectorFromStringTest() {
+    fun `selector from string test`() {
         "a/b/c?arg1=val1".intoSelector().getOrThrow().use { selector: Selector ->
             assertEquals("a/b/c", selector.keyExpr.toString())
-            assertEquals("arg1=val1", selector.parameters)
+            assertEquals("arg1=val1", selector.parameters.toString())
         }
 
         "a/b/c".intoSelector().getOrThrow().use { selector: Selector ->
             assertEquals("a/b/c", selector.keyExpr.toString())
-            assertEquals("", selector.parameters)
+            assertNull(selector.parameters)
         }
 
         assertFailsWith<KeyExprException> { "".intoSelector().getOrThrow() }
+    }
+
+    @Test
+    fun `selector to string test`() {
+        "a/b/c?arg1=val1".intoSelector().getOrThrow().use { selector: Selector ->
+            assertEquals("a/b/c?arg1=val1", selector.toString())
+        }
+
+        "a/b/c".intoSelector().getOrThrow().use { selector: Selector ->
+            assertEquals("a/b/c", selector.toString())
+        }
     }
 }


### PR DESCRIPTION
Providing alignment to the selector API with the following changes:

- Creating the `Parameters` class with the following interface:
- `fun isEmpty(): Boolean`
- `fun containsKey(key: String): Boolean`
- `fun get(key: String): String?`
- `fun getOrDefault(key: String, default: String): String`
- `fun values(key: String): List<String>?`
- `fun insert(key: String, value: String): String?`
- `fun remove(key: String): String?`
- `fun extend(params: IntoParameters)`
- `fun extend(params: Map<String, String>)`
- `fun toMap(): Map<String, String>`

Closes #67 
