### PR TITLE
Improve tryInitLogFromEnv logic

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
@@ -118,8 +118,11 @@ object Zenoh {
      * @see Logger
      */
     fun tryInitLogFromEnv() {
-        ZenohLoad
-        Logger.start(System.getenv(LOG_ENV) ?: "")
+        val logEnv = System.getenv(LOG_ENV)
+        if (logEnv != null) {
+            ZenohLoad
+            Logger.start(logEnv)
+        }
     }
 
     /**


### PR DESCRIPTION
Fix bad behavior introduced in PR #217 where if `tryInitLogFromEnv` is called and the env is not defined, then it's provided an empty string. That doesn't make the logs fail, but it's a wrong logic.