### PR TITLE
Config alignment

### DIFF
--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -19,7 +19,7 @@ use jni::{
     JNIEnv,
 };
 use zenoh::{
-    config::{client, EndPoint},
+    config::{client, peer, EndPoint},
     Config,
 };
 
@@ -150,6 +150,22 @@ fn process_peers(env: &mut JNIEnv, list: &JObject) -> Result<Vec<EndPoint>> {
         rust_vec.push(EndPoint::try_from(str).map_err(|err| session_error!(err))?);
     }
     Ok(rust_vec)
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_loadPeerConfigViaJNI(
+    mut env: JNIEnv,
+    _class: JClass,
+) -> *const Config {
+    || -> Result<*const Config> {
+        let config = peer();
+        Ok(Arc::into_raw(Arc::new(config)))
+    }()
+    .unwrap_or_else(|err| {
+        throw_exception!(env, err);
+        null()
+    })
 }
 
 /// Frees the pointer to the config. The pointer should be valid and should have been obtained through

--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -19,7 +19,7 @@ use jni::{
     sys::{jbyteArray, jstring},
     JNIEnv,
 };
-use zenoh::{Config};
+use zenoh::Config;
 
 use crate::{errors::Result, jni_error};
 use crate::{session_error, throw_exception, utils::decode_string};

--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -213,6 +213,30 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_getJsonViaJN
     })
 }
 
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_insertJson5ViaJNI(
+    mut env: JNIEnv,
+    _class: JClass,
+    cfg_ptr: *const Config,
+    key: JString,
+    value: JString,
+) {
+    || -> Result<()> {
+        let key = decode_string(&mut env, &key)?;
+        let value = decode_string(&mut env, &value)?;
+        let mut config = core::ptr::read(cfg_ptr);
+        let insert_result = config
+            .insert_json5(&key, &value)
+            .map_err(|err| session_error!(err));
+        core::ptr::write(cfg_ptr as *mut _, config);
+        insert_result
+    }()
+    .unwrap_or_else(|err| {
+        throw_exception!(env, err);
+    })
+}
+
 /// Frees the pointer to the config. The pointer should be valid and should have been obtained through
 /// one of the preceding `load` functions. This function should be called upon destruction of the kotlin
 /// Config instance.

--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -15,12 +15,15 @@
 use std::{ptr::null, sync::Arc};
 
 use jni::{
-    objects::{JClass, JString},
+    objects::{JClass, JList, JObject, JString},
     JNIEnv,
 };
-use zenoh::Config;
+use zenoh::{
+    config::{client, EndPoint},
+    Config,
+};
 
-use crate::errors::Result;
+use crate::{errors::Result, jni_error};
 use crate::{session_error, throw_exception, utils::decode_string};
 
 /// Loads the default configuration, returning a raw pointer to it.
@@ -117,6 +120,36 @@ pub extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_loadYamlConfigViaJN
         throw_exception!(env, err);
         null()
     })
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_loadClientConfigViaJNI(
+    mut env: JNIEnv,
+    _class: JClass,
+    list: JObject,
+) -> *const Config {
+    || -> Result<*const Config> {
+        let peers = process_peers(&mut env, &list)?;
+        let config = client(peers);
+        Ok(Arc::into_raw(Arc::new(config)))
+    }()
+    .unwrap_or_else(|err| {
+        throw_exception!(env, err);
+        null()
+    })
+}
+
+fn process_peers(env: &mut JNIEnv, list: &JObject) -> Result<Vec<EndPoint>> {
+    let jmap = JList::from_env(env, list).map_err(|err| jni_error!(err))?;
+    let mut iterator = jmap.iter(env).map_err(|err| jni_error!(err))?;
+    let mut rust_vec: Vec<EndPoint> = Vec::new();
+    while let Some(value) = iterator.next(env).map_err(|err| jni_error!(err))? {
+        let java_str = env.auto_local(JString::from(value));
+        let str = decode_string(env, &java_str)?;
+        rust_vec.push(EndPoint::try_from(str).map_err(|err| session_error!(err))?);
+    }
+    Ok(rust_vec)
 }
 
 /// Frees the pointer to the config. The pointer should be valid and should have been obtained through

--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -15,8 +15,8 @@
 use std::{ptr::null, sync::Arc};
 
 use jni::{
-    objects::{JByteArray, JClass, JString},
-    sys::{jbyteArray, jstring},
+    objects::{JClass, JString},
+    sys::jstring,
     JNIEnv,
 };
 use zenoh::Config;
@@ -118,30 +118,6 @@ pub extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_loadYamlConfigViaJN
         throw_exception!(env, err);
         null()
     })
-}
-
-/// Obtains the id of the config, returning it as a little endian byte array.
-#[no_mangle]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_getIdViaJNI(
-    mut env: JNIEnv,
-    _class: JClass,
-    cfg_ptr: *const Config,
-) -> jbyteArray {
-    let arc_cfg: Arc<Config> = Arc::from_raw(cfg_ptr);
-    let result = || -> Result<jbyteArray> {
-        let bytes = arc_cfg.id().to_le_bytes();
-        let id_bytes = env
-            .byte_array_from_slice(&bytes)
-            .map_err(|err| jni_error!(err))?;
-        Ok(id_bytes.as_raw())
-    }()
-    .unwrap_or_else(|err| {
-        throw_exception!(env, err);
-        JByteArray::default().as_raw()
-    });
-    std::mem::forget(arc_cfg);
-    result
 }
 
 /// Returns the json value associated to the provided [key]. May throw an exception in case of failure, which must be handled

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -330,6 +330,20 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
 }
 
 /**
+ * Returns an empty configuration.
+ */
+fun empty(): Config {
+    return Config.default()
+}
+
+/**
+ * Returns a default configuration.
+ */
+fun default(): Config {
+    return Config.default()
+}
+
+/**
  * Creates a default 'client' mode zenoh net Session configuration.
  */
 fun client(peers: List<String>): Result<Config> {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -269,25 +269,21 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
             return JNIConfig.loadJsonConfig(jsonElement.toString())
         }
 
-        fun peer(): Result<Config> {
-            TODO()
-        }
-
         fun fromEnv(): Result<Config> {
             TODO()
         }
+    }
 
-        fun id(): ZenohID {
-            TODO()
-        }
+    fun id(): ZenohID {
+        TODO()
+    }
 
-        fun getJson(): String {
-            TODO()
-        }
+    fun getJson(): String {
+        TODO()
+    }
 
-        fun insertJson5() {
-            TODO()
-        }
+    fun insertJson5() {
+        TODO()
     }
 
     protected fun finalize() {
@@ -295,6 +291,16 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
     }
 }
 
+/**
+ * Creates a default 'client' mode zenoh net Session configuration.
+ */
 fun client(peers: List<String>): Result<Config> {
     return JNIConfig.loadClientConfig(peers)
+}
+
+/**
+ * Creates a default 'peer' mode zenoh net Session configuration.
+ */
+fun peer(): Result<Config> {
+    return JNIConfig.loadPeerConfig()
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -15,6 +15,7 @@
 package io.zenoh
 
 import io.zenoh.jni.JNIConfig
+import io.zenoh.protocol.ZenohID
 import java.io.File
 import java.nio.file.Path
 import kotlinx.serialization.json.JsonElement
@@ -267,9 +268,33 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         fun fromJsonElement(jsonElement: JsonElement): Result<Config> {
             return JNIConfig.loadJsonConfig(jsonElement.toString())
         }
+
+        fun peer(): Result<Config> {
+            TODO()
+        }
+
+        fun fromEnv(): Result<Config> {
+            TODO()
+        }
+
+        fun id(): ZenohID {
+            TODO()
+        }
+
+        fun getJson(): String {
+            TODO()
+        }
+
+        fun insertJson5() {
+            TODO()
+        }
     }
 
     protected fun finalize() {
         jniConfig.close()
     }
+}
+
+fun client(peers: List<String>): Result<Config> {
+    return JNIConfig.loadClientConfig(peers)
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -127,7 +127,7 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
 
     companion object {
 
-        const val CONFIG_ENV = "ZENOH_CONFIG"
+        private const val CONFIG_ENV = "ZENOH_CONFIG"
 
         /**
          * Returns the default config.
@@ -272,7 +272,7 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         }
 
         /**
-         * Loads the configuration from the env variable [CONFIG_ENV](ZENOH_CONFIG).
+         * Loads the configuration from the env variable [CONFIG_ENV].
          *
          * @return A result with the config.
          */

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -293,12 +293,35 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         return jniConfig.id()
     }
 
+    /**
+     * Returns the json value associated to the [key].
+     */
     fun getJson(key: String): Result<String> {
         return jniConfig.getJson(key)
     }
 
-    fun insertJson5() {
-        TODO()
+    /**
+     * Inserts a json5 value associated to the [key] into the Config.
+     *
+     * Example:
+     * ```kotlin
+     * val config = Config.default()
+     *
+     * // ...
+     * val scouting = """
+     *     {
+     *         multicast: {
+     *             enabled: true,
+     *         }
+     *     }
+     * """.trimIndent()
+     * config.insertJson5("scouting", scouting).getOrThrow()
+     * ```
+     *
+     * @return A result with the status of the operation.
+     */
+    fun insertJson5(key: String, value: String): Result<Unit> {
+        return jniConfig.insertJson5(key, value)
     }
 
     protected fun finalize() {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -286,8 +286,11 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         }
     }
 
+    /**
+     * Returns the id in the config.
+     */
     fun id(): ZenohID {
-        TODO()
+        return jniConfig.id()
     }
 
     fun getJson(): String {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -328,31 +328,3 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         jniConfig.close()
     }
 }
-
-/**
- * Returns an empty configuration.
- */
-fun empty(): Config {
-    return Config.default()
-}
-
-/**
- * Returns a default configuration.
- */
-fun default(): Config {
-    return Config.default()
-}
-
-/**
- * Creates a default 'client' mode zenoh net Session configuration.
- */
-fun client(peers: List<String>): Result<Config> {
-    return JNIConfig.loadClientConfig(peers)
-}
-
-/**
- * Creates a default 'peer' mode zenoh net Session configuration.
- */
-fun peer(): Result<Config> {
-    return JNIConfig.loadPeerConfig()
-}

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -293,8 +293,8 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
         return jniConfig.id()
     }
 
-    fun getJson(): String {
-        TODO()
+    fun getJson(key: String): Result<String> {
+        return jniConfig.getJson(key)
     }
 
     fun insertJson5() {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -287,13 +287,6 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
     }
 
     /**
-     * Returns the id in the config.
-     */
-    fun id(): ZenohID {
-        return jniConfig.id()
-    }
-
-    /**
      * Returns the json value associated to the [key].
      */
     fun getJson(key: String): Result<String> {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -127,6 +127,8 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
 
     companion object {
 
+        const val CONFIG_ENV = "ZENOH_CONFIG"
+
         /**
          * Returns the default config.
          */
@@ -269,8 +271,18 @@ class Config internal constructor(internal val jniConfig: JNIConfig) {
             return JNIConfig.loadJsonConfig(jsonElement.toString())
         }
 
-        fun fromEnv(): Result<Config> {
-            TODO()
+        /**
+         * Loads the configuration from the env variable [CONFIG_ENV](ZENOH_CONFIG).
+         *
+         * @return A result with the config.
+         */
+        fun fromEnv(): Result<Config> = runCatching {
+            val envValue = System.getenv(CONFIG_ENV)
+            if (envValue != null) {
+                return fromFile(File(envValue))
+            } else {
+                throw Exception("Couldn't load env variable: $CONFIG_ENV.")
+            }
         }
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -16,6 +16,7 @@ package io.zenoh.jni
 
 import io.zenoh.Config
 import io.zenoh.ZenohLoad
+import io.zenoh.protocol.ZenohID
 import java.io.File
 import java.nio.file.Path
 
@@ -82,11 +83,19 @@ internal class JNIConfig(internal val ptr: Long) {
         @Throws
         private external fun loadPeerConfigViaJNI(): Long
 
+        @Throws
+        private external fun getIdViaJNI(ptr: Long): ByteArray
+
         /** Frees the underlying native config. */
         private external fun freePtrViaJNI(ptr: Long)
     }
 
     fun close() {
         freePtrViaJNI(ptr)
+    }
+
+    fun id(): ZenohID {
+        val bytes = getIdViaJNI(ptr)
+        return ZenohID(bytes)
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -54,6 +54,11 @@ internal class JNIConfig(internal val ptr: Long) {
             Config(JNIConfig(cfgPtr))
         }
 
+        fun loadClientConfig(peers: List<String>): Result<Config> = runCatching {
+            val cfgPtr = loadClientConfigViaJNI(peers)
+            Config(JNIConfig(cfgPtr))
+        }
+
         @Throws
         private external fun loadDefaultConfigViaJNI(): Long
 
@@ -65,6 +70,9 @@ internal class JNIConfig(internal val ptr: Long) {
 
         @Throws
         private external fun loadYamlConfigViaJNI(rawConfig: String): Long
+
+        @Throws
+        private external fun loadClientConfigViaJNI(peers: List<String>): Long
 
         /** Frees the underlying native config. */
         private external fun freePtrViaJNI(ptr: Long)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -88,6 +88,9 @@ internal class JNIConfig(internal val ptr: Long) {
 
         /** Frees the underlying native config. */
         private external fun freePtrViaJNI(ptr: Long)
+
+        @Throws
+        private external fun getJsonViaJNI(ptr: Long, key: String): String
     }
 
     fun close() {
@@ -97,5 +100,9 @@ internal class JNIConfig(internal val ptr: Long) {
     fun id(): ZenohID {
         val bytes = getIdViaJNI(ptr)
         return ZenohID(bytes)
+    }
+
+    fun getJson(key: String): Result<String> = runCatching {
+        getJsonViaJNI(ptr, key)
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -16,7 +16,6 @@ package io.zenoh.jni
 
 import io.zenoh.Config
 import io.zenoh.ZenohLoad
-import io.zenoh.protocol.ZenohID
 import java.io.File
 import java.nio.file.Path
 
@@ -82,11 +81,6 @@ internal class JNIConfig(internal val ptr: Long) {
 
     fun close() {
         freePtrViaJNI(ptr)
-    }
-
-    fun id(): ZenohID {
-        val bytes = getIdViaJNI(ptr)
-        return ZenohID(bytes)
     }
 
     fun getJson(key: String): Result<String> = runCatching {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -59,6 +59,11 @@ internal class JNIConfig(internal val ptr: Long) {
             Config(JNIConfig(cfgPtr))
         }
 
+        fun loadPeerConfig(): Result<Config> = runCatching {
+            val cfgPtr = loadPeerConfigViaJNI()
+            Config(JNIConfig(cfgPtr))
+        }
+
         @Throws
         private external fun loadDefaultConfigViaJNI(): Long
 
@@ -73,6 +78,9 @@ internal class JNIConfig(internal val ptr: Long) {
 
         @Throws
         private external fun loadClientConfigViaJNI(peers: List<String>): Long
+
+        @Throws
+        private external fun loadPeerConfigViaJNI(): Long
 
         /** Frees the underlying native config. */
         private external fun freePtrViaJNI(ptr: Long)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -55,16 +55,6 @@ internal class JNIConfig(internal val ptr: Long) {
             Config(JNIConfig(cfgPtr))
         }
 
-        fun loadClientConfig(peers: List<String>): Result<Config> = runCatching {
-            val cfgPtr = loadClientConfigViaJNI(peers)
-            Config(JNIConfig(cfgPtr))
-        }
-
-        fun loadPeerConfig(): Result<Config> = runCatching {
-            val cfgPtr = loadPeerConfigViaJNI()
-            Config(JNIConfig(cfgPtr))
-        }
-
         @Throws
         private external fun loadDefaultConfigViaJNI(): Long
 
@@ -76,12 +66,6 @@ internal class JNIConfig(internal val ptr: Long) {
 
         @Throws
         private external fun loadYamlConfigViaJNI(rawConfig: String): Long
-
-        @Throws
-        private external fun loadClientConfigViaJNI(peers: List<String>): Long
-
-        @Throws
-        private external fun loadPeerConfigViaJNI(): Long
 
         @Throws
         private external fun getIdViaJNI(ptr: Long): ByteArray

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIConfig.kt
@@ -86,6 +86,9 @@ internal class JNIConfig(internal val ptr: Long) {
         @Throws
         private external fun getIdViaJNI(ptr: Long): ByteArray
 
+        @Throws
+        private external fun insertJson5ViaJNI(ptr: Long, key: String, value: String): Long
+
         /** Frees the underlying native config. */
         private external fun freePtrViaJNI(ptr: Long)
 
@@ -104,5 +107,9 @@ internal class JNIConfig(internal val ptr: Long) {
 
     fun getJson(key: String): Result<String> = runCatching {
         getJsonViaJNI(ptr, key)
+    }
+
+    fun insertJson5(key: String, value: String): Result<Unit> = runCatching {
+        insertJson5ViaJNI(this.ptr, key, value)
     }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -299,4 +299,9 @@ class ConfigTest {
     fun `client function fails when providing wrongly formatted peers test`() {
         assertTrue(client(listOf("wrong_formatted_peer")).isFailure)
     }
+
+    @Test
+    fun `peer function shoulr create a basic peer config`() {
+        peer().getOrThrow()
+    }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -289,4 +289,14 @@ class ConfigTest {
             serverConfigFile.delete()
         }
     }
+
+    @Test
+    fun `client function should create a basic client config`() {
+        client(listOf("tcp/localhost:7450", "tcp/localhost:7451", "tcp/localhost:7452", "tcp/localhost:7453")).getOrThrow()
+    }
+
+    @Test
+    fun `client function fails when providing wrongly formatted peers test`() {
+        assertTrue(client(listOf("wrong_formatted_peer")).isFailure)
+    }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -341,6 +341,17 @@ class ConfigTest {
     }
 
     @Test
+    fun `config should remain valid despite failing to get json value`() {
+        val config = peer().getOrThrow()
+        val result = config.getJson("non_existent_key")
+        assertTrue(result.isFailure)
+
+        // We perform another operation and it should be ok
+        val mode = config.getJson("mode").getOrThrow()
+        assertEquals("\"peer\"", mode)
+    }
+
+    @Test
     fun `insert json5 function test`() {
         val config = Config.default()
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -292,7 +292,8 @@ class ConfigTest {
 
     @Test
     fun `client function should create a basic client config`() {
-        client(listOf("tcp/localhost:7450", "tcp/localhost:7451", "tcp/localhost:7452", "tcp/localhost:7453")).getOrThrow()
+        val config = client(listOf("tcp/localhost:7450", "tcp/localhost:7451", "tcp/localhost:7452", "tcp/localhost:7453")).getOrThrow()
+        assertEquals("\"client\"", config.getJson("mode").getOrThrow())
     }
 
     @Test
@@ -302,7 +303,8 @@ class ConfigTest {
 
     @Test
     fun `peer function should create a basic peer config`() {
-        peer().getOrThrow()
+        val config = peer().getOrThrow()
+        assertEquals("\"peer\"", config.getJson("mode").getOrThrow())
     }
 
     @Test

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -301,7 +301,7 @@ class ConfigTest {
     }
 
     @Test
-    fun `peer function shoulr create a basic peer config`() {
+    fun `peer function should create a basic peer config`() {
         peer().getOrThrow()
     }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -291,23 +291,6 @@ class ConfigTest {
     }
 
     @Test
-    fun `client function should create a basic client config`() {
-        val config = client(listOf("tcp/localhost:7450", "tcp/localhost:7451", "tcp/localhost:7452", "tcp/localhost:7453")).getOrThrow()
-        assertEquals("\"client\"", config.getJson("mode").getOrThrow())
-    }
-
-    @Test
-    fun `client function fails when providing wrongly formatted peers test`() {
-        assertTrue(client(listOf("wrong_formatted_peer")).isFailure)
-    }
-
-    @Test
-    fun `peer function should create a basic peer config`() {
-        val config = peer().getOrThrow()
-        assertEquals("\"peer\"", config.getJson("mode").getOrThrow())
-    }
-
-    @Test
     fun `config id function test`() {
         val customId = "123456789"
         val config = Config.fromJson("""{
@@ -344,7 +327,21 @@ class ConfigTest {
 
     @Test
     fun `config should remain valid despite failing to get json value`() {
-        val config = peer().getOrThrow()
+        val jsonConfig = """
+        {
+            mode: "peer",
+            connect: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+            scouting: {
+                multicast: {
+                    enabled: false,
+                }
+            }
+        }
+        """.trimIndent()
+
+        val config = Config.fromJson(jsonConfig).getOrThrow()
         val result = config.getJson("non_existent_key")
         assertTrue(result.isFailure)
 

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -339,4 +339,30 @@ class ConfigTest {
         val value2 = config.getJson("mode").getOrThrow()
         assertEquals("\"peer\"", value2)
     }
+
+    @Test
+    fun `insert json5 function test`() {
+        val config = Config.default()
+
+        val endpoints = """["tcp/8.8.8.8:8", "tcp/8.8.8.8:9"]""".trimIndent()
+        config.insertJson5("listen/endpoints", endpoints)
+
+        val jsonValue = config.getJson("listen/endpoints").getOrThrow()
+        println(jsonValue)
+        assertTrue(jsonValue.contains("8.8.8.8"))
+    }
+
+    @Test
+    fun `insert ill formatted json5 should fail and config should remain valid`() {
+        val config = Config.default()
+
+        val illFormattedEndpoints = """["tcp/8.8.8.8:8"""".trimIndent()
+        val result = config.insertJson5("listen/endpoints", illFormattedEndpoints)
+        assertTrue(result.isFailure)
+
+        val correctEndpoints = """["tcp/8.8.8.8:8", "tcp/8.8.8.8:9"]""".trimIndent()
+        config.insertJson5("listen/endpoints", correctEndpoints)
+        val retrievedEndpoints = config.getJson("listen/endpoints").getOrThrow()
+        assertTrue(retrievedEndpoints.contains("8.8.8.8"))
+    }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -291,17 +291,6 @@ class ConfigTest {
     }
 
     @Test
-    fun `config id function test`() {
-        val customId = "123456789"
-        val config = Config.fromJson("""{
-            id: "$customId"
-        }
-        """.trimIndent()).getOrThrow()
-
-        assertEquals(customId, config.id().toString())
-    }
-
-    @Test
     fun `get json function test`() {
         val jsonConfig = """
         {

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -304,4 +304,15 @@ class ConfigTest {
     fun `peer function should create a basic peer config`() {
         peer().getOrThrow()
     }
+
+    @Test
+    fun `config id function test`() {
+        val customId = "123456789"
+        val config = Config.fromJson("""{
+            id: "$customId"
+        }
+        """.trimIndent()).getOrThrow()
+
+        assertEquals(customId, config.id().toString())
+    }
 }

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ConfigTest.kt
@@ -315,4 +315,28 @@ class ConfigTest {
 
         assertEquals(customId, config.id().toString())
     }
+
+    @Test
+    fun `get json function test`() {
+        val jsonConfig = """
+        {
+            mode: "peer",
+            connect: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+            scouting: {
+                multicast: {
+                    enabled: false,
+                }
+            }
+        }
+        """.trimIndent()
+
+        val config = Config.fromJson(jsonConfig).getOrThrow()
+        val value = config.getJson("connect").getOrThrow()
+        assertTrue(value.contains("\"endpoints\":[\"tcp/localhost:7450\"]"))
+
+        val value2 = config.getJson("mode").getOrThrow()
+        assertEquals("\"peer\"", value2)
+    }
 }


### PR DESCRIPTION
Adding the following functionalities to Config.kt:

- `config.getJson(key: String): Result<String>`
- `config.insertJson5(key: String, value: String): Result<Unit>`
- `config.id(): ZenohID`
- `Config.fromEnv(): Result<Config>` (attempts to load the config on the path provided under the environment variable `ZENOH_CONFIG`)