### PR TITLE
Session info

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -34,6 +34,7 @@ tasks {
         "ZBytes",
         "ZDelete",
         "ZGet",
+        "ZInfo",
         "ZPub",
         "ZPubThr",
         "ZPut",

--- a/examples/src/main/kotlin/io.zenoh/ZInfo.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZInfo.kt
@@ -29,11 +29,11 @@ class ZInfo(private val emptyArgs: Boolean) : CliktCommand(
         Zenoh.open(config).onSuccess { session ->
             session.use {
                 val info = session.info()
-                println("zid: ${info.id().getOrThrow()}")
+                println("zid: ${info.zid().getOrThrow()}")
 
-                println("routers zid: ${info.routersId().getOrThrow()}")
+                println("routers zid: ${info.routersZid().getOrThrow()}")
 
-                println("peers zid: ${info.peersId().getOrThrow()}")
+                println("peers zid: ${info.peersZid().getOrThrow()}")
             }
         }.onFailure { exception -> println(exception.message) }
     }

--- a/examples/src/main/kotlin/io.zenoh/ZInfo.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZInfo.kt
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.*
+
+class ZInfo(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Info example"
+) {
+    override fun run() {
+        val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting, mode)
+
+        Zenoh.initLogFromEnvOr("error")
+
+        println("Opening session...")
+        Zenoh.open(config).onSuccess { session ->
+            session.use {
+                val info = session.info()
+
+                println("routers zid: ${info.routersId()}")
+
+                println("peers zid: ${info.peersId()}")
+            }
+        }.onFailure { exception -> println(exception.message) }
+    }
+
+
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+}
+
+fun main(args: Array<String>) = ZInfo(args.isEmpty()).main(args)

--- a/examples/src/main/kotlin/io.zenoh/ZInfo.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZInfo.kt
@@ -29,10 +29,11 @@ class ZInfo(private val emptyArgs: Boolean) : CliktCommand(
         Zenoh.open(config).onSuccess { session ->
             session.use {
                 val info = session.info()
+                println("zid: ${info.id().getOrThrow()}")
 
-                println("routers zid: ${info.routersId()}")
+                println("routers zid: ${info.routersId().getOrThrow()}")
 
-                println("peers zid: ${info.peersId()}")
+                println("peers zid: ${info.peersId().getOrThrow()}")
             }
         }.onFailure { exception -> println(exception.message) }
     }

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -1037,6 +1037,8 @@ fn on_reply_error(
     result
 }
 
+/// Returns a list of zenoh ids as byte arrays corresponding to the peers connected to the session provided.
+///
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getPeersZidViaJNI(
@@ -1045,11 +1047,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getPeersZidViaJNI(
     session_ptr: *const Session,
 ) -> jobject {
     let session = Arc::from_raw(session_ptr);
-    let ids = || -> Result<jobject> {
+    let ids = {
         let peers_zid = session.info().peers_zid().wait();
         let ids = peers_zid.collect::<Vec<ZenohId>>();
         ids_to_java_list(&mut env, ids).map_err(|err| jni_error!(err))
-    }()
+    }
     .unwrap_or_else(|err| {
         throw_exception!(env, err);
         JObject::default().as_raw()
@@ -1058,6 +1060,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getPeersZidViaJNI(
     ids
 }
 
+/// Returns a list of zenoh ids as byte arrays corresponding to the routers connected to the session provided.
+///
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getRoutersZidViaJNI(
@@ -1066,11 +1070,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getRoutersZidViaJNI(
     session_ptr: *const Session,
 ) -> jobject {
     let session = Arc::from_raw(session_ptr);
-    let ids = || -> Result<jobject> {
+    let ids = {
         let peers_zid = session.info().routers_zid().wait();
         let ids = peers_zid.collect::<Vec<ZenohId>>();
         ids_to_java_list(&mut env, ids).map_err(|err| jni_error!(err))
-    }()
+    }
     .unwrap_or_else(|err| {
         throw_exception!(env, err);
         JObject::default().as_raw()
@@ -1079,6 +1083,7 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getRoutersZidViaJNI(
     ids
 }
 
+/// Returns the Zenoh ID as a byte array of the session.
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getZidViaJNI(
@@ -1087,12 +1092,12 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getZidViaJNI(
     session_ptr: *const Session,
 ) -> jbyteArray {
     let session = Arc::from_raw(session_ptr);
-    let ids = || -> Result<jbyteArray> {
+    let ids = {
         let zid = session.info().zid().wait();
         env.byte_array_from_slice(&zid.to_le_bytes())
             .map(|x| x.as_raw())
             .map_err(|err| jni_error!(err))
-    }()
+    }
     .unwrap_or_else(|err| {
         throw_exception!(env, err);
         JByteArray::default().as_raw()

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -872,12 +872,16 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         jniSession?.run { performDelete(keyExpr, delete) }
     }
 
-    internal fun getPeersId(): List<ZenohID> {
-        return jniSession?.peersZid() ?: emptyList()
+    internal fun zid(): Result<ZenohID> {
+        return jniSession?.zid() ?: Result.failure(sessionClosedException)
     }
 
-    internal fun getRoutersId(): List<ZenohID> {
-        return jniSession?.routersZid() ?: emptyList()
+    internal fun getPeersId(): Result<List<ZenohID>> {
+        return jniSession?.peersZid() ?: Result.failure(sessionClosedException)
+    }
+
+    internal fun getRoutersId(): Result<List<ZenohID>> {
+        return jniSession?.routersZid() ?: Result.failure(sessionClosedException)
     }
 
     /** Launches the session through the jni session, returning the [Session] on success. */

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -24,6 +24,7 @@ import io.zenoh.prelude.Encoding
 import io.zenoh.prelude.QoS
 import io.zenoh.protocol.IntoZBytes
 import io.zenoh.protocol.ZBytes
+import io.zenoh.protocol.ZenohID
 import io.zenoh.publication.Delete
 import io.zenoh.publication.Publisher
 import io.zenoh.publication.Put
@@ -802,6 +803,10 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         return jniSession != null
     }
 
+    fun info(): SessionInfo {
+        return SessionInfo(this)
+    }
+
     private fun resolvePublisher(keyExpr: KeyExpr, qos: QoS, reliability: Reliability): Result<Publisher> {
         return jniSession?.run {
             declarePublisher(keyExpr, qos, reliability).onSuccess { declarations.add(it) }
@@ -865,6 +870,14 @@ class Session private constructor(private val config: Config) : AutoCloseable {
 
     private fun resolveDelete(keyExpr: KeyExpr, delete: Delete): Result<Unit> = runCatching {
         jniSession?.run { performDelete(keyExpr, delete) }
+    }
+
+    internal fun getPeersId(): List<ZenohID> {
+        return jniSession?.peersZid() ?: emptyList()
+    }
+
+    internal fun getRoutersId(): List<ZenohID> {
+        return jniSession?.routersZid() ?: emptyList()
     }
 
     /** Launches the session through the jni session, returning the [Session] on success. */

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
@@ -18,15 +18,15 @@ import io.zenoh.protocol.ZenohID
 
 class SessionInfo(private val session: Session) {
 
-    fun id(): ZenohID {
-        TODO()
+    fun id(): Result<ZenohID> {
+        return session.zid()
     }
 
-    fun peersId(): List<ZenohID> {
+    fun peersId(): Result<List<ZenohID>> {
         return session.getPeersId()
     }
 
-    fun routersId(): List<ZenohID> {
+    fun routersId(): Result<List<ZenohID>> {
         return session.getRoutersId()
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
@@ -24,21 +24,21 @@ class SessionInfo(private val session: Session) {
     /**
      *  Return the [ZenohID] of the current Zenoh [Session]
      */
-    fun id(): Result<ZenohID> {
+    fun zid(): Result<ZenohID> {
         return session.zid()
     }
 
     /**
      * Return the [ZenohID] of the zenoh peers the session is currently connected to.
      */
-    fun peersId(): Result<List<ZenohID>> {
+    fun peersZid(): Result<List<ZenohID>> {
         return session.getPeersId()
     }
 
     /**
      * Return the [ZenohID] of the zenoh routers the session is currently connected to.
      */
-    fun routersId(): Result<List<ZenohID>> {
+    fun routersZid(): Result<List<ZenohID>> {
         return session.getRoutersId()
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
@@ -16,16 +16,28 @@ package io.zenoh
 
 import io.zenoh.protocol.ZenohID
 
+/**
+ * Class allowing to obtain the information of a [Session].
+ */
 class SessionInfo(private val session: Session) {
 
+    /**
+     *  Return the [ZenohID] of the current Zenoh [Session]
+     */
     fun id(): Result<ZenohID> {
         return session.zid()
     }
 
+    /**
+     * Return the [ZenohID] of the zenoh peers the session is currently connected to.
+     */
     fun peersId(): Result<List<ZenohID>> {
         return session.getPeersId()
     }
 
+    /**
+     * Return the [ZenohID] of the zenoh routers the session is currently connected to.
+     */
     fun routersId(): Result<List<ZenohID>> {
         return session.getRoutersId()
     }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/SessionInfo.kt
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import io.zenoh.protocol.ZenohID
+
+class SessionInfo(private val session: Session) {
+
+    fun id(): ZenohID {
+        TODO()
+    }
+
+    fun peersId(): List<ZenohID> {
+        return session.getPeersId()
+    }
+
+    fun routersId(): List<ZenohID> {
+        return session.getRoutersId()
+    }
+}

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -252,6 +252,22 @@ internal class JNISession {
     }
 
     @Throws(Exception::class)
+    fun peersZid(): List<ZenohID> {
+        return getPeersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
+    }
+
+    @Throws(Exception::class)
+    fun routersZid(): List<ZenohID> {
+        return getRoutersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
+    }
+
+    @Throws(Exception::class)
+    private external fun getPeersZidViaJNI(ptr: Long): List<ByteArray>
+
+    @Throws(Exception::class)
+    private external fun getRoutersZidViaJNI(ptr: Long): List<ByteArray>
+
+    @Throws(Exception::class)
     private external fun openSessionViaJNI(configPtr: Long): Long
 
     @Throws(Exception::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -251,15 +251,20 @@ internal class JNISession {
         )
     }
 
-    @Throws(Exception::class)
-    fun peersZid(): List<ZenohID> {
-        return getPeersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
+    fun zid(): Result<ZenohID> = runCatching {
+        ZenohID(getZidViaJNI(sessionPtr.get()))
+    }
+
+    fun peersZid(): Result<List<ZenohID>> = runCatching {
+        getPeersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
+    }
+
+    fun routersZid(): Result<List<ZenohID>> = runCatching {
+        getRoutersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
     }
 
     @Throws(Exception::class)
-    fun routersZid(): List<ZenohID> {
-        return getRoutersZidViaJNI(sessionPtr.get()).map { ZenohID(it) }
-    }
+    private external fun getZidViaJNI(ptr: Long): ByteArray
 
     @Throws(Exception::class)
     private external fun getPeersZidViaJNI(ptr: Long): List<ByteArray>

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionInfoTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionInfoTest.kt
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SessionInfoTest {
+
+    @Test
+    fun `peersZid test`() {
+        val jsonConfig = """
+        {
+            mode: "peer",
+            connect: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+        }
+        """.trimIndent()
+
+        val listenConfig = Config.fromJson("""
+        {
+            mode: "peer",
+            listen: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+        }
+        """.trimIndent()).getOrThrow()
+
+        val sessionC = Zenoh.open(listenConfig).getOrThrow()
+        val sessionA = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
+        val sessionB = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
+
+        val idA = sessionA.info().id().getOrThrow()
+        val idB = sessionB.info().id().getOrThrow()
+        val peers = sessionC.info().peersId().getOrThrow()
+        assertTrue(peers.contains(idA))
+        assertTrue(peers.contains(idB))
+
+        sessionA.close()
+        sessionB.close()
+        sessionC.close()
+    }
+
+
+    @Test
+    fun `routersZid test`() {
+        val jsonConfig = """
+        {
+            mode: "router",
+            connect: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+            listen: {
+                endpoints: ["tcp/localhost:7452"],
+            },
+        }
+        """.trimIndent()
+
+        val listenConfig = Config.fromJson("""
+        {
+            mode: "router",
+            listen: {
+                endpoints: ["tcp/localhost:7450"],
+            },
+        }
+        """.trimIndent()).getOrThrow()
+
+        val sessionC = Zenoh.open(listenConfig).getOrThrow()
+        val sessionA = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
+        val sessionB = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
+
+        val idA = sessionA.info().id().getOrThrow()
+        val idB = sessionB.info().id().getOrThrow()
+        val routers = sessionC.info().routersId().getOrThrow()
+        assertTrue(routers.contains(idA))
+        assertTrue(routers.contains(idB))
+
+        sessionA.close()
+        sessionB.close()
+        sessionC.close()
+    }
+
+    @Test
+    fun `zid test`() {
+        val jsonConfig = """
+        {
+            id: "123456",
+        }
+        """.trimIndent()
+
+        val session = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
+        assertEquals("123456", session.info().id().getOrThrow().toString())
+        session.close()
+    }
+}

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionInfoTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/SessionInfoTest.kt
@@ -44,9 +44,9 @@ class SessionInfoTest {
         val sessionA = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
         val sessionB = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
 
-        val idA = sessionA.info().id().getOrThrow()
-        val idB = sessionB.info().id().getOrThrow()
-        val peers = sessionC.info().peersId().getOrThrow()
+        val idA = sessionA.info().zid().getOrThrow()
+        val idB = sessionB.info().zid().getOrThrow()
+        val peers = sessionC.info().peersZid().getOrThrow()
         assertTrue(peers.contains(idA))
         assertTrue(peers.contains(idB))
 
@@ -83,9 +83,9 @@ class SessionInfoTest {
         val sessionA = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
         val sessionB = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
 
-        val idA = sessionA.info().id().getOrThrow()
-        val idB = sessionB.info().id().getOrThrow()
-        val routers = sessionC.info().routersId().getOrThrow()
+        val idA = sessionA.info().zid().getOrThrow()
+        val idB = sessionB.info().zid().getOrThrow()
+        val routers = sessionC.info().routersZid().getOrThrow()
         assertTrue(routers.contains(idA))
         assertTrue(routers.contains(idB))
 
@@ -103,7 +103,7 @@ class SessionInfoTest {
         """.trimIndent()
 
         val session = Zenoh.open(Config.fromJson(jsonConfig).getOrThrow()).getOrThrow()
-        assertEquals("123456", session.info().id().getOrThrow().toString())
+        assertEquals("123456", session.info().zid().getOrThrow().toString())
         session.close()
     }
 }


### PR DESCRIPTION
Adding `SessionInfo` class with the following functions:

- `fun id(): Result<ZenohID>`
- `fun peers(): Result<List<ZenohID>>`
- `fun routers(): Result<List<ZenohID>>`

A Result.failure is returned in case of either:
- JNI error (failure to create a kotlin instance for instance)
- The session has been closed

Also, added the ZInfo example.