### PR TITLE
Align Rust with Reliability exported in zenoh::qos

### DIFF
--- a/zenoh-jni/Cargo.lock
+++ b/zenoh-jni/Cargo.lock
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2940,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "tracing",
  "uhlc",
@@ -2959,12 +2959,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "json5",
  "num_cpus",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "aes",
  "hmac",
@@ -3009,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "bincode",
  "flume 0.11.0",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3056,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "flume 0.11.0",
@@ -3079,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "nix",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "git-version",
  "libloading",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "const_format",
  "rand",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "anyhow",
 ]
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "event-listener",
  "futures",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "futures",
  "tokio",
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#b3b71a7805f31f72b53c2d83807163e542847406"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-jni/src/utils.rs
+++ b/zenoh-jni/src/utils.rs
@@ -23,8 +23,7 @@ use jni::{
 use zenoh::{
     bytes::{Encoding, ZBytes},
     internal::buffers::ZSlice,
-    pubsub::Reliability,
-    qos::{CongestionControl, Priority},
+    qos::{CongestionControl, Priority, Reliability},
     query::{ConsolidationMode, QueryTarget},
 };
 


### PR DESCRIPTION
Move zenoh::pubsub::Reliability to zenoh::qos::Reliability. To be merged after https://github.com/eclipse-zenoh/zenoh/pull/1457.