### PR TITLE
Publisher alignment

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -121,15 +121,17 @@ class Session private constructor(private val config: Config) : AutoCloseable {
      *
      * @param keyExpr The [KeyExpr] the publisher will be associated to.
      * @param qos The [QoS] configuration of the publisher.
+     * @param encoding The default [Encoding] for the publications.
      * @param reliability The [Reliability] the publisher wishes to obtain from the network.
      * @return The result of the declaration, returning the publisher in case of success.
      */
     fun declarePublisher(
         keyExpr: KeyExpr,
         qos: QoS = QoS.default(),
+        encoding: Encoding = Encoding.default(),
         reliability: Reliability = Reliability.RELIABLE
     ): Result<Publisher> {
-        return resolvePublisher(keyExpr, qos, reliability)
+        return resolvePublisher(keyExpr, qos, encoding, reliability)
     }
 
     /**
@@ -807,9 +809,9 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         return SessionInfo(this)
     }
 
-    private fun resolvePublisher(keyExpr: KeyExpr, qos: QoS, reliability: Reliability): Result<Publisher> {
+    private fun resolvePublisher(keyExpr: KeyExpr, qos: QoS, encoding: Encoding, reliability: Reliability): Result<Publisher> {
         return jniSession?.run {
-            declarePublisher(keyExpr, qos, reliability).onSuccess { declarations.add(it) }
+            declarePublisher(keyExpr, qos, encoding, reliability).onSuccess { declarations.add(it) }
         } ?: Result.failure(sessionClosedException)
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -63,7 +63,7 @@ internal class JNISession {
         closeSessionViaJNI(sessionPtr.get())
     }
 
-    fun declarePublisher(keyExpr: KeyExpr, qos: QoS, reliability: Reliability): Result<Publisher> = runCatching {
+    fun declarePublisher(keyExpr: KeyExpr, qos: QoS, encoding: Encoding, reliability: Reliability): Result<Publisher> = runCatching {
         val publisherRawPtr = declarePublisherViaJNI(
             keyExpr.jniKeyExpr?.ptr ?: 0,
             keyExpr.keyExpr,
@@ -76,6 +76,7 @@ internal class JNISession {
         Publisher(
             keyExpr,
             qos,
+            encoding,
             JNIPublisher(publisherRawPtr),
         )
     }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/SetIntersectionLevel.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/SetIntersectionLevel.kt
@@ -14,6 +14,11 @@
 
 package io.zenoh.keyexpr
 
+/**
+ * The possible relations between two sets.
+ *
+ * Note that [EQUALS] implies [INCLUDES], which itself implies [INTERSECTS].
+ */
 enum class SetIntersectionLevel(internal val value: Int) {
     DISJOINT(0),
     INTERSECTS(1),

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
@@ -65,6 +65,7 @@ import io.zenoh.protocol.into
 class Publisher internal constructor(
     val keyExpr: KeyExpr,
     val qos: QoS,
+    val encoding: Encoding,
     private var jniPublisher: JNIPublisher?,
 ) : SessionDeclaration, AutoCloseable {
 
@@ -79,11 +80,10 @@ class Publisher internal constructor(
     fun priority() = qos.priority
 
     /** Performs a PUT operation on the specified [keyExpr] with the specified [payload]. */
-    fun put(payload: IntoZBytes, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(payload, encoding, attachment) ?: InvalidPublisherResult
-
+    fun put(payload: IntoZBytes, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(payload, encoding ?: this.encoding, attachment) ?: InvalidPublisherResult
 
     /** Performs a PUT operation on the specified [keyExpr] with the specified string [message]. */
-    fun put(message: String, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(message.into(), encoding, attachment) ?: InvalidPublisherResult
+    fun put(message: String, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(message.into(), encoding ?: this.encoding, attachment) ?: InvalidPublisherResult
 
     /**
      * Performs a DELETE operation on the specified [keyExpr]

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/publication/Publisher.kt
@@ -72,9 +72,11 @@ class Publisher internal constructor(
         private val InvalidPublisherResult = Result.failure<Unit>(SessionException("Publisher is not valid."))
     }
 
-    val congestionControl = qos.congestionControl
-    val priority = qos.priority
-    val express = qos.express
+    /** Get the congestion control applied when routing the data. */
+    fun congestionControl() = qos.congestionControl
+
+    /** Get the priority of the written data. */
+    fun priority() = qos.priority
 
     /** Performs a PUT operation on the specified [keyExpr] with the specified [payload]. */
     fun put(payload: IntoZBytes, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(payload, encoding, attachment) ?: InvalidPublisherResult

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/PublisherTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/PublisherTest.kt
@@ -36,7 +36,7 @@ class PublisherTest {
     fun setUp() {
         session = Session.open(Config.default()).getOrThrow()
         keyExpr = "example/testing/keyexpr".intoKeyExpr().getOrThrow()
-        publisher = session.declarePublisher(keyExpr).getOrThrow()
+        publisher = session.declarePublisher(keyExpr, encoding = Encoding.ZENOH_STRING).getOrThrow()
         subscriber = session.declareSubscriber(keyExpr, callback = { sample ->
             receivedSamples.add(sample)
         }).getOrThrow()
@@ -74,5 +74,12 @@ class PublisherTest {
         publisher.delete()
         assertEquals(1, receivedSamples.size)
         assertEquals(SampleKind.DELETE, receivedSamples[0].kind)
+    }
+
+    @Test
+    fun `when encoding is not provided a put should fallback to the publisher encoding`() {
+        publisher.put("Test")
+        assertEquals(1, receivedSamples.size)
+        assertEquals(Encoding.ZENOH_STRING, receivedSamples[0].encoding)
     }
 }


### PR DESCRIPTION
- Adding default encoding argument when declaring a publisher
- Replacing `congestionControl` and `priority` attributes with equivalent functions.