### PR TITLE
Native lib loading refactor

### DIFF
--- a/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
@@ -108,7 +108,7 @@ internal actual object ZenohLoad {
     }
 
     private fun loadLibraryAsInputStream(target: Target): Result<InputStream> = runCatching {
-        val libUrl = ClassLoader.getSystemClassLoader().getResourceAsStream("$target/$target.zip")!!
+        val libUrl = javaClass.getResourceAsStream("$target/$target.zip")!!
         val uncompressedLibFile = unzipLibrary(libUrl)
         return Result.success(FileInputStream(uncompressedLibFile.getOrThrow()))
     }


### PR DESCRIPTION
Equivalent to https://github.com/eclipse-zenoh/zenoh-java/pull/153

Issue: when exporting a project using Zenoh-Kotlin as a JAR, the native library fails to be loaded in that project.