### PR TITLE
Refactoring JVM target determination + adding arm64 support for windows

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -58,6 +58,12 @@ jobs:
               os: windows-2019,
               build-cmd: "cargo",
             }
+          - {
+            target: aarch64-pc-windows-msvc,
+            arch: arm64,
+            os: windows-2019,
+            build-cmd: "cargo",
+          }
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Target.kt
+++ b/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Target.kt
@@ -16,6 +16,7 @@ package io.zenoh
 
 internal enum class Target {
     WINDOWS_X86_64_MSVC,
+    WINDOWS_AARCH64_MSVC,
     LINUX_X86_64,
     LINUX_AARCH64,
     APPLE_AARCH64,
@@ -24,6 +25,7 @@ internal enum class Target {
     override fun toString(): String {
         return when (this) {
             WINDOWS_X86_64_MSVC -> "x86_64-pc-windows-msvc"
+            WINDOWS_AARCH64_MSVC -> "aarch64-pc-windows-msvc"
             LINUX_X86_64 -> "x86_64-unknown-linux-gnu"
             LINUX_AARCH64 -> "aarch64-unknown-linux-gnu"
             APPLE_AARCH64 -> "aarch64-apple-darwin"

--- a/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/jvmMain/kotlin/io/zenoh/Zenoh.kt
@@ -45,24 +45,31 @@ internal actual object ZenohLoad {
      */
     private fun determineTarget(): Result<Target> = runCatching {
         val osName = System.getProperty("os.name").lowercase()
-        val osArch = System.getProperty("os.arch")
+        val osArch = System.getProperty("os.arch").lowercase()
 
         val target = when {
             osName.contains("win") -> when {
-                osArch.contains("x86_64") || osArch.contains("amd64") -> Target.WINDOWS_X86_64_MSVC
-                else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
+                osArch.contains("x86_64") || osArch.contains("amd64") || osArch.contains("x64") ->
+                    Target.WINDOWS_X86_64_MSVC
+                osArch.contains("aarch64") || osArch.contains("arm64") ->
+                    Target.WINDOWS_AARCH64_MSVC
+                else -> throw UnsupportedOperationException("Unsupported architecture on Windows: $osArch")
             }
 
-            osName.contains("mac") -> when {
-                osArch.contains("x86_64") || osArch.contains("amd64") -> Target.APPLE_X86_64
-                osArch.contains("aarch64") -> Target.APPLE_AARCH64
-                else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
+            osName.contains("mac") || osName.contains("darwin") || osName.contains("os x") -> when {
+                osArch.contains("x86_64") || osArch.contains("amd64") || osArch.contains("x64") ->
+                    Target.APPLE_X86_64
+                osArch.contains("aarch64") || osArch.contains("arm64") ->
+                    Target.APPLE_AARCH64
+                else -> throw UnsupportedOperationException("Unsupported architecture on macOS: $osArch")
             }
 
             osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> when {
-                osArch.contains("x86_64") || osArch.contains("amd64") -> Target.LINUX_X86_64
-                osArch.contains("aarch64") -> Target.LINUX_AARCH64
-                else -> throw UnsupportedOperationException("Unsupported architecture: $osArch")
+                osArch.contains("x86_64") || osArch.contains("amd64") || osArch.contains("x64") ->
+                    Target.LINUX_X86_64
+                osArch.contains("aarch64") || osArch.contains("arm64") ->
+                    Target.LINUX_AARCH64
+                else -> throw UnsupportedOperationException("Unsupported architecture on Linux/Unix: $osArch")
             }
 
             else -> throw UnsupportedOperationException("Unsupported platform: $osName")


### PR DESCRIPTION
ARM64 may not be properly handled when dynamically loading the native libs (see https://github.com/eclipse-zenoh/zenoh-java/issues/155). This PR aims to solve this issue.

On top of that, we add arm64 support for windows.