### PR TITLE
Android logging: pstore logs disabled

### DIFF
--- a/zenoh-jni/src/logger.rs
+++ b/zenoh-jni/src/logger.rs
@@ -43,11 +43,25 @@ pub extern "C" fn Java_io_zenoh_Logger_00024Companion_startLogsViaJNI(
 ) {
     || -> ZResult<()> {
         let log_level = parse_filter(&mut env, filter)?;
-        android_logd_logger::builder()
-            .parse_filters(log_level.as_str())
-            .tag_target_strip()
-            .prepend_module(true)
-            .init();
+        #[cfg(target_os = "android")]
+        {
+            android_logd_logger::builder()
+                .parse_filters(log_level.as_str())
+                .tag_target_strip()
+                .prepend_module(true)
+                .pstore(false)
+                .init();
+        }
+
+        #[cfg(not(target_os = "android"))]
+        {
+            android_logd_logger::builder()
+                .parse_filters(log_level.as_str())
+                .tag_target_strip()
+                .prepend_module(true)
+                .init();
+        }
+
         Ok(())
     }()
     .unwrap_or_else(|err| throw_exception!(env, err))


### PR DESCRIPTION
On some cases (not always) when enabling logging on Android devices, the applications crash due to logging to persistent storage (pstore). This is caused becuase by default, the underlying native library used for android logging sets pstore to true by default.
This PR introduces changes in which if the target is an Android target, it sets the pstore logging to false.

For the record, a discussion regarding this issue took place here: https://discord.com/channels/914168414178779197/1287754571073978449.