### PR TITLE
Scouting: closing channel when scout is closed.

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
@@ -54,7 +54,7 @@ object Zenoh {
         config: Config? = null
     ): Result<Scout<Unit>> {
         ZenohLoad
-        return JNIScout.scout(whatAmI = whatAmI, callback = callback, receiver = Unit, config = config)
+        return JNIScout.scout(whatAmI = whatAmI, callback = callback, receiver = Unit, onClose = {}, config = config)
     }
 
     /**
@@ -78,6 +78,7 @@ object Zenoh {
             whatAmI = whatAmI,
             callback = { hello -> handler.handle(hello) },
             receiver = handler.receiver(),
+            onClose = handler::onClose,
             config = config
         )
     }
@@ -104,6 +105,7 @@ object Zenoh {
             whatAmI = whatAmI,
             callback = { hello -> handler.handle(hello) },
             receiver = handler.receiver(),
+            onClose = handler::onClose,
             config = config
         )
     }


### PR DESCRIPTION
This PR fixes the following error: when a scout is launched using a `Channel`, the channel is not closed upon closing the scout.