### PR TITLE
fix: inherit secrets to pass to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets: inherit
 
   publish-android:
     name: Publish Android package
@@ -89,6 +90,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets: inherit
 
   publish-dokka:
     name: Publish documentation


### PR DESCRIPTION
Suggestion from eclipse-foundation engineers related to error reading the secret required for maven publication.