### PR TITLE
fix: remove debug from gradle

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -12,10 +12,6 @@ on:
         description: Target branch
         type: string
         required: false
-      debug:
-        description: If true, pass --debug flag to gradle
-        type: boolean
-        required: false
   workflow_dispatch:
 
 env:
@@ -74,21 +70,15 @@ jobs:
             echo "PUB_MODE=-PSNAPSHOT" >> $GITHUB_ENV
           fi
 
-      - name: Set debug env var
-        run: |
-          if [[ "${{ inputs.debug }}" == "true" ]]; then
-            echo "DEBUG=--debug" >> $GITHUB_ENV
-          fi
-
       - name: Gradle Publish Android Package to GitHub packages repository
-        run: ./gradlew publishAndroidReleasePublicationToGithubPackagesRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }} ${{ env.DEBUG }}
+        run: ./gradlew publishAndroidReleasePublicationToGithubPackagesRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
           ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
       - name: Gradle Publish Android Package to Maven Central repository
-        run: ./gradlew publishAndroidReleasePublicationToMavenCentralRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }} ${{ env.DEBUG }}
+        run: ./gradlew publishAndroidReleasePublicationToMavenCentralRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -12,10 +12,6 @@ on:
         description: Target branch
         type: string
         required: false
-      debug:
-        description: "Pass --debug to gradle"
-        type: boolean
-        required: false
   workflow_dispatch:
 
 env:
@@ -179,14 +175,8 @@ jobs:
             echo "PUB_MODE=-PSNAPSHOT" >> $GITHUB_ENV
           fi
 
-      - name: Set debug env var
-        run: |
-          if [[ "${{ inputs.debug }}" == "true" ]]; then
-            echo "DEBUG=--debug" >> $GITHUB_ENV
-          fi
-
       - name: Gradle Publish JVM Package to GitHub packages repository
-        run: ./gradlew publishJvmPublicationToGithubPackagesRepository -PremotePublication=true ${{ env.PUB_MODE }} ${{ env.DEBUG }}
+        run: ./gradlew publishJvmPublicationToGithubPackagesRepository -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
@@ -195,7 +185,7 @@ jobs:
 
 
       - name: Gradle Publish JVM Package to Maven Central repository
-        run: ./gradlew publishJvmPublicationToMavenCentralRepository -PremotePublication=true ${{ env.PUB_MODE }} ${{ env.DEBUG }}
+        run: ./gradlew publishJvmPublicationToMavenCentralRepository -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,6 @@ on:
         type: string
         description: Release branch
         required: false
-      debug:
-        type: boolean
-        description: Pass --debug flag to gradle
-        required: false
 
 jobs:
   tag:
@@ -79,7 +75,6 @@ jobs:
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
       branch: ${{ needs.tag.outputs.branch }}
-      debug: ${{ inputs.debug  || false }}
     permissions:
       contents: read
       packages: write
@@ -92,7 +87,6 @@ jobs:
     with:
       snapshot: ${{ !(inputs.live-run || false) }}
       branch: ${{ needs.tag.outputs.branch }}
-      debug: ${{ inputs.debug || false }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
gradle docs recommends not using --debug in CI since it can potentially leak secrets.