### PR TITLE
Adding Querier (unstable) to Zenoh-Kotlin

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -40,6 +40,7 @@ tasks {
         "ZPub",
         "ZPubThr",
         "ZPut",
+        "ZQuerier",
         "ZQueryable",
         "ZScout",
         "ZSub",

--- a/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
@@ -17,6 +17,7 @@ package io.zenoh
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.long
+import io.zenoh.annotations.Unstable
 import io.zenoh.bytes.ZBytes
 import io.zenoh.query.QueryTarget
 import io.zenoh.query.intoSelector
@@ -26,6 +27,7 @@ class ZQuerier(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Querier example"
 ) {
 
+    @OptIn(Unstable::class)
     override fun run() {
         val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting, mode)
 

--- a/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.*
+import com.github.ajalt.clikt.parameters.types.long
+import io.zenoh.bytes.ZBytes
+import io.zenoh.query.QueryTarget
+import io.zenoh.query.intoSelector
+import java.time.Duration
+
+class ZQuerier(private val emptyArgs: Boolean) : CliktCommand(
+    help = "Zenoh Querier example"
+) {
+
+    override fun run() {
+        val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting, mode)
+
+        Zenoh.initLogFromEnvOr("error")
+
+        val session = Zenoh.open(config).getOrThrow()
+        val selector = selector.intoSelector().getOrThrow()
+
+        val target = target ?.let{ QueryTarget.valueOf(it.uppercase()) } ?: QueryTarget.BEST_MATCHING
+        val timeout = Duration.ofMillis(timeout)
+        val querier = session.declareQuerier(selector.keyExpr, target, timeout = timeout).getOrThrow()
+
+        for (idx in 0..Int.MAX_VALUE) {
+            Thread.sleep(1000)
+            val payload = "[${idx.toString().padStart(4, ' ')}] ${payload ?: ""}"
+            println("Querying '$selector' with payload: '$payload'...")
+            querier.get(callback = {
+                it.result.onSuccess { sample ->
+                    println(">> Received ('${sample.keyExpr}': '${sample.payload}')")
+                }.onFailure { error ->
+                    println(">> Received (ERROR: '${error.message}')")
+                }
+            }, payload = ZBytes.from(payload), parameters = selector.parameters)
+        }
+    }
+
+    private val selector by option(
+        "-s",
+        "--selector",
+        help = "The selection of resources to query [default: demo/example/**]",
+        metavar = "selector"
+    ).default("demo/example/**")
+    private val payload by option(
+        "-p", "--payload", help = "An optional payload to put in the query.", metavar = "payload"
+    )
+    private val target by option(
+        "-t",
+        "--target",
+        help = "The target queryables of the query. Default: BEST_MATCHING. " + "[possible values: BEST_MATCHING, ALL, ALL_COMPLETE]",
+        metavar = "target"
+    )
+    private val timeout by option(
+        "-o", "--timeout", help = "The query timeout in milliseconds [default: 10000]", metavar = "timeout"
+    ).long().default(10000)
+    private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")
+    private val mode by option(
+        "-m",
+        "--mode",
+        help = "The session mode. Default: peer. Possible values: [peer, client, router]",
+        metavar = "mode"
+    ).default("peer")
+    private val connect: List<String> by option(
+        "-e", "--connect", help = "Endpoints to connect to.", metavar = "connect"
+    ).multiple()
+    private val listen: List<String> by option(
+        "-l", "--listen", help = "Endpoints to listen on.", metavar = "listen"
+    ).multiple()
+    private val noMulticastScouting: Boolean by option(
+        "--no-multicast-scouting", help = "Disable the multicast-based scouting mechanism."
+    ).flag(default = false)
+}
+
+fun main(args: Array<String>) = ZQuerier(args.isEmpty()).main(args)

--- a/zenoh-jni/src/lib.rs
+++ b/zenoh-jni/src/lib.rs
@@ -18,6 +18,7 @@ mod key_expr;
 mod liveliness;
 mod logger;
 mod publisher;
+mod querier;
 mod query;
 mod queryable;
 mod scouting;

--- a/zenoh-jni/src/querier.rs
+++ b/zenoh-jni/src/querier.rs
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::sync::Arc;
+
+use jni::{
+    objects::{JByteArray, JClass, JObject, JString},
+    sys::jint,
+    JNIEnv,
+};
+use zenoh::{key_expr::KeyExpr, query::Querier, Wait};
+
+use crate::{
+    errors::ZResult,
+    key_expr::process_kotlin_key_expr,
+    session::{on_reply_error, on_reply_success},
+    throw_exception,
+    utils::{
+        decode_byte_array, decode_encoding, decode_string, get_callback_global_ref, get_java_vm,
+        load_on_close,
+    },
+    zerror,
+};
+
+/// Perform a Zenoh GET through a querier.
+/// 
+/// This function is meant to be called from Java/Kotlin code through JNI.
+///
+/// Parameters:
+/// - `env`: The JNI environment.
+/// - `_class`: The JNI class.
+/// - `querier_ptr`: The raw pointer to the querier.
+/// - `key_expr_ptr`: A raw pointer to the [KeyExpr] provided to the kotlin querier. May be null in case of using an
+///     undeclared key expression.
+/// - `key_expr_str`: String representation of the key expression used during the querier declaration.
+///     It won't be considered in case a key_expr_ptr to a declared key expression is provided.
+/// - `selector_params`: Optional selector parameters for the query.
+/// - `callback`: Reference to the Kotlin callback to be run upon receiving a reply.
+/// - `on_close`: Reference to a kotlin callback to be run upon finishing the get operation, mostly used for closing a provided channel.
+/// - `attachment`: Optional attachment.
+/// - `payload`: Optional payload for the query.
+/// - `encoding_id`: Encoding id of the payload provided.
+/// - `encoding_schema`: Encoding schema of the payload provided.
+/// 
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
+    mut env: JNIEnv,
+    _class: JClass,
+    querier_ptr: *const Querier,
+    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_str: JString,
+    selector_params: /*nullable*/ JString,
+    callback: JObject,
+    on_close: JObject,
+    attachment: /*nullable*/ JByteArray,
+    payload: /*nullable*/ JByteArray,
+    encoding_id: jint,
+    encoding_schema: /*nullable*/ JString,
+) {
+    let querier = Arc::from_raw(querier_ptr);
+    let _ = || -> ZResult<()> {
+        let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
+        let java_vm = Arc::new(get_java_vm(&mut env)?);
+        let callback_global_ref = get_callback_global_ref(&mut env, callback)?;
+        let on_close_global_ref = get_callback_global_ref(&mut env, on_close)?;
+        let on_close = load_on_close(&java_vm, on_close_global_ref);
+        let mut get_builder = querier.get().callback(move |reply| {
+            || -> ZResult<()> {
+                on_close.noop(); // Does nothing, but moves `on_close` inside the closure so it gets destroyed with the closure
+                tracing::debug!("Receiving reply through JNI: {:?}", reply);
+                let mut env = java_vm.attach_current_thread_as_daemon().map_err(|err| {
+                    zerror!("Unable to attach thread for GET query callback: {}.", err)
+                })?;
+
+                match reply.result() {
+                    Ok(sample) => {
+                        on_reply_success(&mut env, reply.replier_id(), sample, &callback_global_ref)
+                    }
+                    Err(error) => {
+                        on_reply_error(&mut env, reply.replier_id(), error, &callback_global_ref)
+                    }
+                }
+            }()
+            .unwrap_or_else(|err| tracing::error!("Error on get callback: {err}"));
+        });
+
+        if !selector_params.is_null() {
+            let params = decode_string(&mut env, &selector_params)?;
+            get_builder = get_builder.parameters(params)
+        };
+
+        if !payload.is_null() {
+            let encoding = decode_encoding(&mut env, encoding_id, &encoding_schema)?;
+            get_builder = get_builder.encoding(encoding);
+            get_builder = get_builder.payload(decode_byte_array(&env, payload)?);
+        }
+
+        if !attachment.is_null() {
+            let attachment = decode_byte_array(&env, attachment)?;
+            get_builder = get_builder.attachment::<Vec<u8>>(attachment);
+        }
+
+        get_builder
+            .wait()
+            .map(|_| tracing::trace!("Performing get on '{key_expr}'.",))
+            .map_err(|err| zerror!(err))
+    }()
+    .map_err(|err| throw_exception!(env, err));
+    std::mem::forget(querier);
+}
+
+/// 
+/// Frees the pointer of the querier. 
+///
+/// After a call to this function, no further jni operations should be performed using the querier associated to the raw pointer provided.
+/// 
+#[no_mangle]
+#[allow(non_snake_case)]
+pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_freePtrViaJNI(
+    _env: JNIEnv,
+    _: JClass,
+    querier_ptr: *const Querier<'static>,
+) {
+    Arc::from_raw(querier_ptr);
+}

--- a/zenoh-jni/src/querier.rs
+++ b/zenoh-jni/src/querier.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 /// Perform a Zenoh GET through a querier.
-/// 
+///
 /// This function is meant to be called from Java/Kotlin code through JNI.
 ///
 /// Parameters:
@@ -52,7 +52,7 @@ use crate::{
 /// - `payload`: Optional payload for the query.
 /// - `encoding_id`: Encoding id of the payload provided.
 /// - `encoding_schema`: Encoding schema of the payload provided.
-/// 
+///
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
@@ -121,11 +121,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
     std::mem::forget(querier);
 }
 
-/// 
-/// Frees the pointer of the querier. 
+///
+/// Frees the pointer of the querier.
 ///
 /// After a call to this function, no further jni operations should be performed using the querier associated to the raw pointer provided.
-/// 
+///
 #[no_mangle]
 #[allow(non_snake_case)]
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_freePtrViaJNI(

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -23,7 +23,7 @@ use zenoh::{
     config::Config,
     key_expr::KeyExpr,
     pubsub::{Publisher, Subscriber},
-    query::{Query, Queryable, ReplyError, Selector},
+    query::{Querier, Query, Queryable, ReplyError, Selector},
     sample::Sample,
     session::{Session, ZenohId},
     Wait,
@@ -507,6 +507,52 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
         tracing::debug!("Subscriber declared on '{}'.", key_expr);
         std::mem::forget(session);
         Ok(Arc::into_raw(Arc::new(subscriber)))
+    }()
+    .unwrap_or_else(|err| {
+        throw_exception!(env, err);
+        null()
+    })
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQuerierViaJNI(
+    mut env: JNIEnv,
+    _class: JClass,
+    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_str: JString,
+    session_ptr: *const Session,
+    target: jint,
+    consolidation: jint,
+    congestion_control: jint,
+    priority: jint,
+    is_express: jboolean,
+    timeout_ms: jlong,
+) -> *const Querier<'static> {
+    let session = Arc::from_raw(session_ptr);
+    || -> ZResult<*const Querier<'static>> {
+        let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
+        let query_target = decode_query_target(target)?;
+        let consolidation = decode_consolidation(consolidation)?;
+        let congestion_control = decode_congestion_control(congestion_control)?;
+        let timeout = Duration::from_millis(timeout_ms as u64);
+        let priority = decode_priority(priority)?;
+        tracing::debug!("Declaring querier on '{}'...", key_expr);
+
+        let querier = session
+            .declare_querier(key_expr.to_owned())
+            .congestion_control(congestion_control)
+            .consolidation(consolidation)
+            .express(is_express != 0)
+            .target(query_target)
+            .priority(priority)
+            .timeout(timeout)
+            .wait()
+            .map_err(|err| zerror!(err))?;
+
+        tracing::debug!("Querier declared on '{}'.", key_expr);
+        std::mem::forget(session);
+        Ok(Arc::into_raw(Arc::new(querier)))
     }()
     .unwrap_or_else(|err| {
         throw_exception!(env, err);

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -515,9 +515,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
 }
 
 /// Declare a Zenoh querier via JNI.
-/// 
+///
 /// This function is meant to be called from Java/Kotlin code through JNI.
-/// 
+///
 /// Parameters:
 /// - `env`: The JNI environment.
 /// - `_class`: The JNI class.

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -514,6 +514,23 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
     })
 }
 
+/// Declare a Zenoh querier via JNI.
+/// 
+/// This function is meant to be called from Java/Kotlin code through JNI.
+/// 
+/// Parameters:
+/// - `env`: The JNI environment.
+/// - `_class`: The JNI class.
+/// - `key_expr_ptr`: A raw pointer to the [KeyExpr] to be used for the querier. May be null in case of using an
+///     undeclared key expression.
+/// - `key_expr_str`: String representation of the key expression to be used to declare the querier.
+///     It won't be considered in case a key_expr_ptr to a declared key expression is provided.
+/// - `target`: The ordinal value of the query target enum value.
+/// - `consolidation`: The ordinal value of the consolidation enum value.
+/// - `congestion_control`: The ordinal value of the congestion control enum value.
+/// - `priority`: The ordinal value of the priority enum value.
+/// - `is_express`: The boolean express value of the QoS provided.
+/// - `timeout_ms`: The timeout in milliseconds.
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQuerierViaJNI(

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -378,6 +378,29 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         }, handler.receiver(), complete)
     }
 
+    /**
+     * Declare a [Querier].
+     *
+     * A querier allows to send queries to a queryable.
+     *
+     * Queriers are automatically undeclared when dropped.
+     *
+     * Example:
+     * ```kotlin
+     * val session = Zenoh.open(config).getOrThrow();
+     * val keyExpr = "a/b/c".intoKeyExpr().getOrThrow();
+     *
+     * val querier = session.declareQuerier(keyExpr).getOrThrow();
+     * querier.get(callback = {
+     *         it.result.onSuccess { sample ->
+     *             println(">> Received ('${sample.keyExpr}': '${sample.payload}')")
+     *         }.onFailure { error ->
+     *             println(">> Received (ERROR: '${error.message}')")
+     *         }
+     *     }
+     * )
+     * ```
+     */
     fun declareQuerier(
         keyExpr: KeyExpr,
         target: QueryTarget = QueryTarget.BEST_MATCHING,
@@ -761,7 +784,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         timeout: Duration
     ): Result<Querier> {
         return jniSession?.run {
-            declareQuerier(keyExpr, target, consolidation, qos, timeout).onSuccess { declarations.add(it) }
+            declareQuerier(keyExpr, target, consolidation, qos, timeout)
         } ?: Result.failure(sessionClosedException)
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -14,6 +14,7 @@
 
 package io.zenoh
 
+import io.zenoh.annotations.Unstable
 import io.zenoh.exceptions.ZError
 import io.zenoh.handlers.Callback
 import io.zenoh.handlers.ChannelHandler
@@ -401,6 +402,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
      * )
      * ```
      */
+    @Unstable
     fun declareQuerier(
         keyExpr: KeyExpr,
         target: QueryTarget = QueryTarget.BEST_MATCHING,
@@ -776,6 +778,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         } ?: Result.failure(sessionClosedException)
     }
 
+    @OptIn(Unstable::class)
     private fun resolveQuerier(
         keyExpr: KeyExpr,
         target: QueryTarget,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -378,6 +378,16 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         }, handler.receiver(), complete)
     }
 
+    fun declareQuerier(
+        keyExpr: KeyExpr,
+        target: QueryTarget = QueryTarget.BEST_MATCHING,
+        qos: QoS = QoS.default(),
+        consolidation: ConsolidationMode = ConsolidationMode.NONE,
+        timeout: Duration = Duration.ofMillis(10000)
+    ): Result<Querier> {
+        return resolveQuerier(keyExpr, target, consolidation, qos, timeout)
+    }
+
     /**
      * Declare a [KeyExpr].
      *
@@ -740,6 +750,18 @@ class Session private constructor(private val config: Config) : AutoCloseable {
     ): Result<Queryable<R>> {
         return jniSession?.run {
             declareQueryable(keyExpr, callback, onClose, receiver, complete).onSuccess { declarations.add(it) }
+        } ?: Result.failure(sessionClosedException)
+    }
+
+    private fun resolveQuerier(
+        keyExpr: KeyExpr,
+        target: QueryTarget,
+        consolidation: ConsolidationMode,
+        qos: QoS,
+        timeout: Duration
+    ): Result<Querier> {
+        return jniSession?.run {
+            declareQuerier(keyExpr, target, consolidation, qos, timeout).onSuccess { declarations.add(it) }
         } ?: Result.failure(sessionClosedException)
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -405,7 +405,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         keyExpr: KeyExpr,
         target: QueryTarget = QueryTarget.BEST_MATCHING,
         qos: QoS = QoS.default(),
-        consolidation: ConsolidationMode = ConsolidationMode.NONE,
+        consolidation: ConsolidationMode = ConsolidationMode.AUTO,
         timeout: Duration = Duration.ofMillis(10000)
     ): Result<Querier> {
         return resolveQuerier(keyExpr, target, consolidation, qos, timeout)
@@ -500,7 +500,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         attachment: IntoZBytes? = null,
         timeout: Duration = Duration.ofMillis(10000),
         target: QueryTarget = QueryTarget.BEST_MATCHING,
-        consolidation: ConsolidationMode = ConsolidationMode.NONE,
+        consolidation: ConsolidationMode = ConsolidationMode.AUTO,
         onClose: (() -> Unit)? = null
     ): Result<Unit> {
         return resolveGet(
@@ -577,7 +577,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         attachment: IntoZBytes? = null,
         timeout: Duration = Duration.ofMillis(10000),
         target: QueryTarget = QueryTarget.BEST_MATCHING,
-        consolidation: ConsolidationMode = ConsolidationMode.NONE,
+        consolidation: ConsolidationMode = ConsolidationMode.AUTO,
         onClose: (() -> Unit)? = null
     ): Result<R> {
         return resolveGet(

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/annotations/Annotations.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/annotations/Annotations.kt
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.annotations
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This feature is unstable and may change in future releases."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class Unstable

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuerier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuerier.kt
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.jni
+
+import io.zenoh.bytes.Encoding
+import io.zenoh.bytes.IntoZBytes
+import io.zenoh.bytes.into
+import io.zenoh.config.ZenohId
+import io.zenoh.exceptions.ZError
+import io.zenoh.handlers.Callback
+import io.zenoh.jni.callbacks.JNIGetCallback
+import io.zenoh.jni.callbacks.JNIOnCloseCallback
+import io.zenoh.keyexpr.KeyExpr
+import io.zenoh.qos.CongestionControl
+import io.zenoh.qos.Priority
+import io.zenoh.qos.QoS
+import io.zenoh.query.Parameters
+import io.zenoh.query.Reply
+import io.zenoh.query.ReplyError
+import io.zenoh.sample.Sample
+import io.zenoh.sample.SampleKind
+import org.apache.commons.net.ntp.TimeStamp
+
+internal class JNIQuerier(val ptr: Long) {
+
+    fun <R> performGet(
+        keyExpr: KeyExpr,
+        parameters: Parameters?,
+        callback: Callback<Reply>,
+        onClose: () -> Unit,
+        receiver: R,
+        attachment: IntoZBytes?,
+        payload: IntoZBytes?,
+        encoding: Encoding?
+    ): Result<R> = runCatching {
+        val getCallback = JNIGetCallback {
+                replierId: ByteArray?,
+                success: Boolean,
+                keyExpr: String?,
+                payload: ByteArray,
+                encodingId: Int,
+                encodingSchema: String?,
+                kind: Int,
+                timestampNTP64: Long,
+                timestampIsValid: Boolean,
+                attachmentBytes: ByteArray?,
+                express: Boolean,
+                priority: Int,
+                congestionControl: Int,
+            ->
+            val reply: Reply
+            if (success) {
+                val timestamp = if (timestampIsValid) TimeStamp(timestampNTP64) else null
+                val sample = Sample(
+                    KeyExpr(keyExpr!!, null),
+                    payload.into(),
+                    Encoding(encodingId, schema = encodingSchema),
+                    SampleKind.fromInt(kind),
+                    timestamp,
+                    QoS(CongestionControl.fromInt(congestionControl), Priority.fromInt(priority), express),
+                    attachmentBytes?.into()
+                )
+                reply = Reply(replierId?.let { ZenohId(it) }, Result.success(sample))
+            } else {
+                reply = Reply(
+                    replierId?.let { ZenohId(it) }, Result.failure(
+                        ReplyError(
+                            payload.into(),
+                            Encoding(encodingId, schema = encodingSchema)
+                        )
+                    )
+                )
+            }
+            callback.run(reply)
+        }
+        getViaJNI(this.ptr,
+            keyExpr.jniKeyExpr?.ptr ?: 0,
+            keyExpr.keyExpr,
+            parameters?.toString(),
+            getCallback,
+            onClose,
+            attachment?.into()?.bytes,
+            payload?.into()?.bytes,
+            encoding?.id ?: Encoding.default().id,
+            encoding?.schema
+        )
+        receiver
+    }
+
+    fun close() {
+        freePtrViaJNI(ptr)
+    }
+
+    @Throws(ZError::class)
+    private external fun getViaJNI(
+        querierPtr: Long,
+        keyExprPtr: Long,
+        keyExprString: String,
+        parameters: String?,
+        callback: JNIGetCallback,
+        onClose: JNIOnCloseCallback,
+        attachmentBytes: ByteArray?,
+        payload: ByteArray?,
+        encodingId: Int,
+        encodingSchema: String?,
+    )
+
+    private external fun freePtrViaJNI(ptr: Long)
+}

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -27,6 +27,7 @@ import io.zenoh.bytes.IntoZBytes
 import io.zenoh.config.ZenohId
 import io.zenoh.bytes.into
 import io.zenoh.Config
+import io.zenoh.annotations.Unstable
 import io.zenoh.pubsub.Delete
 import io.zenoh.pubsub.Publisher
 import io.zenoh.pubsub.Put
@@ -136,6 +137,7 @@ internal class JNISession {
         Queryable(keyExpr, receiver, JNIQueryable(queryableRawPtr))
     }
 
+    @OptIn(Unstable::class)
     fun declareQuerier(
         keyExpr: KeyExpr,
         target: QueryTarget,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -136,6 +136,20 @@ internal class JNISession {
         Queryable(keyExpr, receiver, JNIQueryable(queryableRawPtr))
     }
 
+    fun declareQuerier(
+        keyExpr: KeyExpr,
+        target: QueryTarget,
+        consolidation: ConsolidationMode,
+        qos: QoS,
+        timeout: Duration
+    ): Result<Querier> = runCatching {
+        val querierRawPtr = declareQuerierViaJNI(
+            keyExpr.jniKeyExpr?.ptr ?: 0, keyExpr.keyExpr, sessionPtr.get(), target.ordinal, consolidation.ordinal,
+            qos.congestionControl.ordinal, qos.priority.ordinal, qos.express, timeout.toMillis()
+        )
+        Querier(keyExpr, qos, JNIQuerier(querierRawPtr))
+    }
+
     fun <R> performGet(
         selector: Selector,
         callback: Callback<Reply>,
@@ -311,6 +325,19 @@ internal class JNISession {
         callback: JNIQueryableCallback,
         onClose: JNIOnCloseCallback,
         complete: Boolean
+    ): Long
+
+    @Throws(ZError::class)
+    private external fun declareQuerierViaJNI(
+        keyExprPtr: Long,
+        keyExprString: String,
+        sessionPtr: Long,
+        target: Int,
+        consolidation: Int,
+        congestionControl: Int,
+        priority: Int,
+        express: Boolean,
+        timeoutMs: Long
     ): Long
 
     @Throws(ZError::class)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
@@ -14,6 +14,7 @@
 
 package io.zenoh.query
 
+import io.zenoh.annotations.Unstable
 import io.zenoh.bytes.Encoding
 import io.zenoh.bytes.IntoZBytes
 import io.zenoh.exceptions.ZError
@@ -48,6 +49,7 @@ import kotlinx.coroutines.channels.Channel
  * ```
  *
  */
+@Unstable
 class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private var jniQuerier: JNIQuerier?) :
     SessionDeclaration, AutoCloseable {
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh.query
+
+import io.zenoh.bytes.Encoding
+import io.zenoh.bytes.IntoZBytes
+import io.zenoh.exceptions.ZError
+import io.zenoh.handlers.Callback
+import io.zenoh.handlers.ChannelHandler
+import io.zenoh.handlers.Handler
+import io.zenoh.jni.JNIQuerier
+import io.zenoh.keyexpr.KeyExpr
+import io.zenoh.qos.QoS
+import io.zenoh.session.SessionDeclaration
+import kotlinx.coroutines.channels.Channel
+
+class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private var jniQuerier: JNIQuerier?) :
+    SessionDeclaration, AutoCloseable {
+
+    fun get(
+        channel: Channel<Reply>,
+        parameters: Parameters? = null,
+        payload: IntoZBytes? = null,
+        encoding: Encoding? = null,
+        attachment: IntoZBytes? = null
+    ): Result<Channel<Reply>> {
+        val handler = ChannelHandler(channel)
+        return jniQuerier?.performGet(
+            keyExpr,
+            parameters,
+            handler::handle,
+            handler::onClose,
+            handler.receiver(),
+            attachment,
+            payload,
+            encoding
+        ) ?: throw ZError("Querier is not valid.")
+    }
+
+    fun get(
+        callback: Callback<Reply>,
+        parameters: Parameters? = null,
+        payload: IntoZBytes? = null,
+        encoding: Encoding? = null,
+        attachment: IntoZBytes? = null
+    ): Result<Unit> {
+        return jniQuerier?.performGet(
+            keyExpr,
+            parameters,
+            callback,
+            {},
+            Unit,
+            attachment,
+            payload,
+            encoding
+        ) ?: throw ZError("Querier is not valid.")
+    }
+
+    fun <R> get(
+        handler: Handler<Reply, R>,
+        parameters: Parameters? = null,
+        payload: IntoZBytes? = null,
+        encoding: Encoding? = null,
+        attachment: IntoZBytes? = null
+    ): Result<R> {
+        return jniQuerier?.performGet(
+            keyExpr,
+            parameters,
+            handler::handle,
+            handler::onClose,
+            handler.receiver(),
+            attachment,
+            payload,
+            encoding
+        ) ?: throw ZError("Querier is not valid.")
+    }
+
+    fun congestionControl() = qos.congestionControl
+
+    fun priority() = qos.priority
+
+    override fun undeclare() {
+        jniQuerier?.close()
+        jniQuerier = null
+    }
+
+    override fun close() {
+        undeclare()
+    }
+
+    // matching status
+    // matching listener
+    // accepts replies
+}

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QuerierTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QuerierTest.kt
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package io.zenoh
+
+import io.zenoh.bytes.Encoding
+import io.zenoh.bytes.ZBytes
+import io.zenoh.keyexpr.KeyExpr
+import io.zenoh.keyexpr.intoKeyExpr
+import io.zenoh.qos.QoS
+import io.zenoh.query.Reply
+import io.zenoh.sample.Sample
+import io.zenoh.sample.SampleKind
+import kotlinx.coroutines.runBlocking
+import org.apache.commons.net.ntp.TimeStamp
+import java.time.Instant
+import java.util.*
+import kotlin.test.*
+
+class QuerierTest {
+
+    companion object {
+        val testPayload = ZBytes.from("Hello queryable")
+    }
+
+    private lateinit var session: Session
+    private lateinit var testKeyExpr: KeyExpr
+
+    @BeforeTest
+    fun setUp() {
+        session = Session.open(Config.default()).getOrThrow()
+        testKeyExpr = "example/testing/keyexpr".intoKeyExpr().getOrThrow()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        session.close()
+        testKeyExpr.close()
+    }
+
+    /** Test validating both Queryable and get operations. */
+    @Test
+    fun querier_runsWithCallback() = runBlocking {
+        val sample = Sample(
+            testKeyExpr,
+            testPayload,
+            Encoding.default(),
+            SampleKind.PUT,
+            TimeStamp(Date.from(Instant.now())),
+            QoS()
+        )
+        val examplePayload = ZBytes.from("Example payload")
+        val exampleAttachment = ZBytes.from("Example attachment")
+
+        val queryable = session.declareQueryable(testKeyExpr, callback = { query ->
+            assertEquals(exampleAttachment, query.attachment)
+            assertEquals(examplePayload, query.payload)
+            query.reply(testKeyExpr, payload = sample.payload, timestamp = sample.timestamp)
+        }).getOrThrow()
+
+        val querier = session.declareQuerier(testKeyExpr).getOrThrow()
+
+        var receivedReply: Reply? = null
+        querier.get(
+            callback = { reply -> receivedReply = reply},
+            payload = examplePayload,
+            attachment = exampleAttachment
+        )
+
+        assertEquals(sample, receivedReply?.result?.getOrThrow())
+
+        queryable.close()
+        querier.close()
+    }
+}

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QuerierTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QuerierTest.kt
@@ -14,6 +14,7 @@
 
 package io.zenoh
 
+import io.zenoh.annotations.Unstable
 import io.zenoh.bytes.Encoding
 import io.zenoh.bytes.ZBytes
 import io.zenoh.keyexpr.KeyExpr
@@ -50,6 +51,7 @@ class QuerierTest {
     }
 
     /** Test validating both Queryable and get operations. */
+    @OptIn(Unstable::class)
     @Test
     fun querier_runsWithCallback() = runBlocking {
         val sample = Sample(


### PR DESCRIPTION
This PR provides the querier functionality on https://github.com/eclipse-zenoh/zenoh/pull/1591.

It also features a querier example, has been tested manually as well as through unit tests.
 
However this PR does not introduce the following functions available on the Rust API:

- `querier.matching_status()`
- `querier.matching_listener()`
- `querier.accepts_replies()`
- `querier.id()`


