### PR TITLE
Downgrade Java and minSdkVersion to broaden device compatibility

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(8)
 }
 
 dependencies {

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -41,10 +41,10 @@ if (androidEnabled) {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(8)
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = "11"
+            kotlinOptions.jvmTarget = "1.8"
         }
         testRuns["test"].executionTask.configure {
             val zenohPaths = "../zenoh-jni/target/$buildMode"
@@ -78,7 +78,7 @@ kotlin {
         if (androidEnabled) {
             val androidUnitTest by getting {
                 dependencies {
-                    implementation(kotlin("test-junit"))
+                    implementation(kotlin("test-junit5"))
                 }
             }
         }
@@ -246,17 +246,17 @@ enum class BuildMode {
 fun Project.configureAndroid() {
     extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
         namespace = "io.zenoh"
-        compileSdk = 30
+        compileSdk = 27
 
         ndkVersion = "26.0.10792818"
 
         defaultConfig {
-            minSdk = 30
+            minSdk = 27
         }
 
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
 
         buildTypes {


### PR DESCRIPTION
This change downgrades the java version to 8 and the minSdkVersion to 27 in order to be compatible with a wider range of devices.

I had to change the `implementation(kotlin("test-junit"))` to `implementation(kotlin("test-junit5"))` in order for the project to build.