### PR TITLE
Nexus publish

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -12,7 +12,22 @@ on:
         description: Target branch
         type: string
         required: false
+      github_publish:
+        type: boolean
+        required: false
+        default: true
+      maven_publish:
+        type: boolean
+        required: false
+        default: true
   workflow_dispatch:
+    inputs:
+      github_publish:
+        description: 'Publish to github packages'
+        default: true
+      maven_publish:
+        description: 'Publish to Maven Central'
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -70,7 +85,8 @@ jobs:
             echo "PUB_MODE=-PSNAPSHOT" >> $GITHUB_ENV
           fi
 
-      - name: Gradle Publish Android Package to GitHub packages repository
+      - if: ${{ github.event.inputs.github_publish == 'true' }}
+        name: Gradle Publish Android Package to GitHub packages repository
         run: ./gradlew publishAndroidReleasePublicationToGithubPackagesRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +95,8 @@ jobs:
           ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
           ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
-      - name: Gradle Publish Android Package to Maven Central repository
+      - if: ${{ github.event.inputs.maven_publish == 'true' }}
+        name: Gradle Publish Android Package to Maven Central repository
         run: ./gradlew publishAndroidReleasePublicationToMavenCentralRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -97,7 +97,9 @@ jobs:
 
       - if: ${{ github.event.inputs.maven_publish == 'true' }}
         name: Gradle Publish Android Package to Maven Central repository
-        run: ./gradlew publishAndroidReleasePublicationToMavenCentralRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
+        run: |
+          ./gradlew publishAndroidReleasePublicationToSonatypeRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
+          ./gradlew closeAndReleaseSonatypeStagingRepository
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -12,7 +12,22 @@ on:
         description: Target branch
         type: string
         required: false
+      github_publish:
+        type: boolean
+        required: false
+        default: true
+      maven_publish:
+        type: boolean
+        required: false
+        default: true
   workflow_dispatch:
+    inputs:
+      github_publish:
+        description: 'Publish to github packages'
+        default: "true"
+      maven_publish:
+        description: 'Publish to Maven Central'
+        default: "true"
 
 env:
   CARGO_TERM_COLOR: always
@@ -175,7 +190,8 @@ jobs:
             echo "PUB_MODE=-PSNAPSHOT" >> $GITHUB_ENV
           fi
 
-      - name: Gradle Publish JVM Package to GitHub packages repository
+      - if: ${{ github.event.inputs.github_publish == 'true' }}
+        name: Gradle Publish JVM Package to GitHub packages repository
         run: ./gradlew publishJvmPublicationToGithubPackagesRepository -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -184,8 +200,8 @@ jobs:
           ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
           ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
-
-      - name: Gradle Publish JVM Package to Maven Central repository
+      - if: ${{ github.event.inputs.maven_publish == 'true' }}
+        name: Gradle Publish JVM Package to Maven Central repository
         run: ./gradlew publishJvmPublicationToMavenCentralRepository -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -202,7 +202,9 @@ jobs:
 
       - if: ${{ github.event.inputs.maven_publish == 'true' }}
         name: Gradle Publish JVM Package to Maven Central repository
-        run: ./gradlew publishJvmPublicationToMavenCentralRepository -PremotePublication=true ${{ env.PUB_MODE }}
+        run: |
+          ./gradlew publishJvmPublicationToSonatypeRepository -PremotePublication=true ${{ env.PUB_MODE }}
+          ./gradlew closeAndReleaseSonatypeStagingRepository
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,13 @@ plugins {
     id("org.jetbrains.dokka") version "1.8.20" apply false
     id("com.adarshr.test-logger") version "3.2.0" apply false
     kotlin("plugin.serialization") version "1.9.0" apply false
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,10 @@ plugins {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            username = System.getenv("ORG_OSSRH_USERNAME")
+            password = System.getenv("ORG_OSSRH_PASSWORD")
+        }
     }
 }
 

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -157,18 +157,6 @@ kotlin {
                     password = System.getenv("GITHUB_TOKEN")
                 }
             }
-            maven {
-                name = "MavenCentral"
-                url = uri(if (project.hasProperty("SNAPSHOT"))
-                    "https://oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                )
-                credentials {
-                    username = System.getenv("ORG_OSSRH_USERNAME")
-                    password = System.getenv("ORG_OSSRH_PASSWORD")
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
- Adding the [Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) to gradle for the publishing processes
- Modifying the workflows to use the nexus publish tasks
- Modifying the workflows also to allow to manually trigger either the github publication or the maven publication or both by enabling or disabling them from the actions panel: 
![image](https://github.com/user-attachments/assets/6f9c31a4-15eb-41b6-8e2f-e2fdcded49d2)
