### PR TITLE
Fix selector "null" parameter

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -208,7 +208,7 @@ internal class JNISession {
         getViaJNI(
             selector.keyExpr.jniKeyExpr?.ptr ?: 0,
             selector.keyExpr.keyExpr,
-            selector.parameters.toString(),
+            selector.parameters?.toString(),
             sessionPtr.get(),
             getCallback,
             onClose,


### PR DESCRIPTION
## Issue:

When sending query to "a/b/c" selector (for instance), the queryable was receiving "a/b/c?null" as selector. 

## Fix:

Bug caused by missing '?' null check.

## Tested

Manually + added unit test