### PR TITLE
Examples refactor

### DIFF
--- a/examples/src/main/kotlin/io.zenoh/ZDelete.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZDelete.kt
@@ -27,12 +27,11 @@ class ZDelete(private val emptyArgs: Boolean) : CliktCommand(
         Zenoh.initLogFromEnvOr("error")
 
         println("Opening session...")
-        Zenoh.open(config).onSuccess { session ->
-            session.use {
-                key.intoKeyExpr().onSuccess { keyExpr ->
-                    println("Deleting resources matching '$keyExpr'...")
-                    session.delete(keyExpr)
-                }
+        val session = Zenoh.open(config).getOrThrow()
+        session.use {
+            key.intoKeyExpr().onSuccess { keyExpr ->
+                println("Deleting resources matching '$keyExpr'...")
+                session.delete(keyExpr)
             }
         }
     }

--- a/examples/src/main/kotlin/io.zenoh/ZGet.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZGet.kt
@@ -18,14 +18,15 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.long
 import io.zenoh.bytes.ZBytes
+import io.zenoh.handlers.Handler
 import io.zenoh.sample.SampleKind
 import io.zenoh.query.QueryTarget
+import io.zenoh.query.Reply
 import io.zenoh.query.Selector
 import io.zenoh.query.intoSelector
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
 
 class ZGet(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh Get example"
@@ -39,44 +40,43 @@ class ZGet(private val emptyArgs: Boolean) : CliktCommand(
         val session = Zenoh.open(config).getOrThrow()
         val selector = selector.intoSelector().getOrThrow()
 
+        // Run the Get query through one of the examples below:
         runChannelExample(session, selector)
-//         runCallbackExample(session, selector)
+        // runCallbackExample(session, selector)
+        // runHandlerExample(session, selector)
 
         session.close()
     }
 
     private fun runChannelExample(session: Session, selector: Selector) {
-        session.get(selector,
+        val channelReceiver = session.get(selector,
             channel = Channel(),
             payload = payload?.let { ZBytes.from(it) },
             target = target?.let { QueryTarget.valueOf(it.uppercase()) } ?: QueryTarget.BEST_MATCHING,
             attachment = attachment?.let { ZBytes.from(it) },
             timeout = Duration.ofMillis(timeout)
-        )
-            .onSuccess { channelReceiver ->
-                runBlocking {
-                    for (reply in channelReceiver) {
-                        reply.result.onSuccess { sample ->
-                            when (sample.kind) {
-                                SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
-                                SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
-                            }
-                        }.onFailure { error ->
-                            println("Received (ERROR: '${error.message}')")
-                        }
+        ).getOrThrow()
+        runBlocking {
+            for (reply in channelReceiver) {
+                reply.result.onSuccess { sample ->
+                    when (sample.kind) {
+                        SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
+                        SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
                     }
+                }.onFailure { error ->
+                    println("Received (ERROR: '${error.message}')")
                 }
             }
+        }
     }
 
     private fun runCallbackExample(session: Session, selector: Selector) {
-        val countDownLatch = CountDownLatch(1)
         session.get(selector,
             payload = payload?.let { ZBytes.from(it) },
             target = target?.let { QueryTarget.valueOf(it.uppercase()) } ?: QueryTarget.BEST_MATCHING,
             attachment = attachment?.let { ZBytes.from(it) },
             timeout = Duration.ofMillis(timeout),
-            callback = {reply ->
+            callback = { reply ->
                 reply.result.onSuccess { sample ->
                     when (sample.kind) {
                         SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
@@ -86,12 +86,34 @@ class ZGet(private val emptyArgs: Boolean) : CliktCommand(
                     println("Received (ERROR: '${error.message}')")
                 }
             },
-            onClose = {
-                countDownLatch.countDown()
-            }
         ).getOrThrow()
+    }
 
-        countDownLatch.await()
+    private fun runHandlerExample(session: Session, selector: Selector) {
+        // Create your own handler implementation
+        class ExampleHandler : Handler<Reply, Unit> {
+            override fun handle(t: Reply) {
+                t.result.onSuccess { sample ->
+                    when (sample.kind) {
+                        SampleKind.PUT -> println("Received ('${sample.keyExpr}': '${sample.payload}')")
+                        SampleKind.DELETE -> println("Received (DELETE '${sample.keyExpr}')")
+                    }
+                }.onFailure { error ->
+                    println("Received (ERROR: '${error.message}')")
+                }
+            }
+
+            override fun receiver() {}
+            override fun onClose() {}
+        }
+
+        session.get(selector,
+            payload = payload?.let { ZBytes.from(it) },
+            target = target?.let { QueryTarget.valueOf(it.uppercase()) } ?: QueryTarget.BEST_MATCHING,
+            attachment = attachment?.let { ZBytes.from(it) },
+            timeout = Duration.ofMillis(timeout),
+            handler = ExampleHandler(), // Provide a handler instance
+        ).getOrThrow()
     }
 
     private val selector by option(

--- a/examples/src/main/kotlin/io.zenoh/ZInfo.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZInfo.kt
@@ -26,16 +26,12 @@ class ZInfo(private val emptyArgs: Boolean) : CliktCommand(
         Zenoh.initLogFromEnvOr("error")
 
         println("Opening session...")
-        Zenoh.open(config).onSuccess { session ->
-            session.use {
-                val info = session.info()
-                println("zid: ${info.zid().getOrThrow()}")
-
-                println("routers zid: ${info.routersZid().getOrThrow()}")
-
-                println("peers zid: ${info.peersZid().getOrThrow()}")
-            }
-        }.onFailure { exception -> println(exception.message) }
+        val session = Zenoh.open(config).getOrThrow()
+        val info = session.info()
+        println("zid: ${info.zid().getOrThrow()}")
+        println("routers zid: ${info.routersZid().getOrThrow()}")
+        println("peers zid: ${info.peersZid().getOrThrow()}")
+        session.close()
     }
 
 

--- a/examples/src/main/kotlin/io.zenoh/ZPong.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPong.kt
@@ -25,12 +25,12 @@ import java.util.concurrent.CountDownLatch
 class ZPong(private val emptyArgs: Boolean) : CliktCommand(
     help = "Zenoh ZPong example"
 ) {
-    val latch = CountDownLatch(1)
 
     override fun run() {
         val config = loadConfig(emptyArgs, configFile, connect, listen, noMulticastScouting, mode)
 
         Zenoh.initLogFromEnvOr("error")
+        val latch = CountDownLatch(1)
 
         println("Opening session...")
         val session = Zenoh.open(config).getOrThrow()

--- a/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPubThr.kt
@@ -47,27 +47,26 @@ class ZPubThr(private val emptyArgs: Boolean) : CliktCommand(
             priority = priorityInput?.let { Priority.entries[it] } ?: Priority.DATA,
         )
 
-        Zenoh.open(config).onSuccess {
-            it.use { session ->
-                session.declarePublisher("test/thr".intoKeyExpr().getOrThrow(), qos = qos).onSuccess { pub ->
-                    println("Publisher declared on test/thr.")
-                    var count: Long = 0
-                    var start = System.currentTimeMillis()
-                    val number = number.toLong()
-                    println("Press CTRL-C to quit...")
-                    while (true) {
-                        pub.put(payload).getOrThrow()
-                        if (statsPrint) {
-                            if (count < number) {
-                                count++
-                            } else {
-                                val throughput = count * 1000 / (System.currentTimeMillis() - start)
-                                println("$throughput msgs/s")
-                                count = 0
-                                start = System.currentTimeMillis()
-                            }
-                        }
-                    }
+        val session = Zenoh.open(config).getOrThrow()
+        val keyExpr = "test/thr".intoKeyExpr().getOrThrow()
+        val publisher = session.declarePublisher(keyExpr, qos = qos).getOrThrow()
+
+        println("Publisher declared on test/thr.")
+        var count: Long = 0
+        var start = System.currentTimeMillis()
+        val number = number.toLong()
+
+        println("Press CTRL-C to quit...")
+        while (true) {
+            publisher.put(payload).getOrThrow()
+            if (statsPrint) {
+                if (count < number) {
+                    count++
+                } else {
+                    val throughput = count * 1000 / (System.currentTimeMillis() - start)
+                    println("$throughput msgs/s")
+                    count = 0
+                    start = System.currentTimeMillis()
                 }
             }
         }

--- a/examples/src/main/kotlin/io.zenoh/ZPut.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZPut.kt
@@ -29,16 +29,13 @@ class ZPut(private val emptyArgs: Boolean) : CliktCommand(
         Zenoh.initLogFromEnvOr("error")
 
         println("Opening Session...")
-        Zenoh.open(config).onSuccess { session ->
-            session.use {
-                key.intoKeyExpr().onSuccess { keyExpr ->
-                    keyExpr.use {
-                        session.put(keyExpr, ZBytes.from(value), attachment = attachment?.let { ZBytes.from(it) })
-                            .onSuccess { println("Putting Data ('$keyExpr': '$value')...") }
-                    }
-                }
-            }
-        }.onFailure { println(it.message) }
+        val session = Zenoh.open(config).getOrThrow()
+        val keyExpr = key.intoKeyExpr().getOrThrow()
+
+        session.put(keyExpr, ZBytes.from(value), attachment = attachment?.let { ZBytes.from(it) })
+            .onSuccess { println("Putting Data ('$keyExpr': '$value')...") }.getOrThrow()
+
+        session.close()
     }
 
     private val configFile by option("-c", "--config", help = "A configuration file.", metavar = "config")

--- a/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
+++ b/examples/src/main/kotlin/io.zenoh/ZQuerier.kt
@@ -52,6 +52,8 @@ class ZQuerier(private val emptyArgs: Boolean) : CliktCommand(
                 }
             }, payload = ZBytes.from(payload), parameters = selector.parameters)
         }
+
+        session.close()
     }
 
     private val selector by option(
@@ -61,12 +63,12 @@ class ZQuerier(private val emptyArgs: Boolean) : CliktCommand(
         metavar = "selector"
     ).default("demo/example/**")
     private val payload by option(
-        "-p", "--payload", help = "An optional payload to put in the query.", metavar = "payload"
+        "-p", "--payload", help = "An optional payload to put in the queries.", metavar = "payload"
     )
     private val target by option(
         "-t",
         "--target",
-        help = "The target queryables of the query. Default: BEST_MATCHING. " + "[possible values: BEST_MATCHING, ALL, ALL_COMPLETE]",
+        help = "The target queryables of the querier. Default: BEST_MATCHING. " + "[possible values: BEST_MATCHING, ALL, ALL_COMPLETE]",
         metavar = "target"
     )
     private val timeout by option(


### PR DESCRIPTION
In this PR we attempt to display more didactic examples by
- reducing the nesting by using `getOrThrow()` instead of `onSuccess()` and `onFailure()`
- showing alternative implementations for multiple examples, showing how to use Channels, Handlers and Callbacks.