### PR TITLE
docs(versioning): adding dokka versioning plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
         classpath("org.mozilla.rust-android-gradle:plugin:0.9.3")
         classpath("com.android.tools.build:gradle:7.4.2")
+        classpath("org.jetbrains.dokka:versioning-plugin:1.9.10")
     }
 }
 
@@ -31,7 +32,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.10" apply false
     id("org.jetbrains.kotlin.multiplatform") version "1.9.0" apply false
     id("org.mozilla.rust-android-gradle.rust-android") version "0.9.3" apply false
-    id("org.jetbrains.dokka") version "1.8.20" apply false
+    id("org.jetbrains.dokka") version "1.9.10" apply false
     id("com.adarshr.test-logger") version "3.2.0" apply false
     kotlin("plugin.serialization") version "1.9.0" apply false
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -13,6 +13,8 @@
 //
 
 import com.nishtahir.CargoExtension
+import org.jetbrains.dokka.versioning.VersioningConfiguration
+import org.jetbrains.dokka.versioning.VersioningPlugin
 
 plugins {
     kotlin("multiplatform")
@@ -283,5 +285,25 @@ fun Project.configureCargo() {
             "x86",
             "x86_64",
         )
+    }
+}
+
+val dokkaPlugin by configurations
+dependencies {
+    dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.9.10")
+}
+
+tasks.dokkaHtml {
+    val lastDocsVersionDirectory = project.rootProject.projectDir.resolve("docs")
+    val olderDocsVersionsDirectory = project.rootProject.projectDir.resolve("docs/older")
+
+    pluginConfiguration<VersioningPlugin, VersioningConfiguration> {
+        renderVersionsNavigationOnAllPages = true
+        // Because we want to keep versioning for the documentation, we specify both the directory pointing to the last
+        // version of the documentation (under /docs) and the directories containing the older versions (under docs/older).
+        // This way running `gradle dokkaHtml` after upgrading the version of the repository will take into consideration
+        // those old versions, which will be accessible via a dropdown menu.
+        olderVersionsDir = file(olderDocsVersionsDirectory)
+        olderVersions = arrayListOf(file(lastDocsVersionDirectory))
     }
 }


### PR DESCRIPTION
## Overview

This PR introduces the dokka versioning plugin (see https://kotlin.github.io/dokka/1.4.30/user_guide/versioning/versioning/).

This allows to display a dropdown menu on the documentation site with the old versions:

![Screenshot 2025-01-03 at 16 58 54](https://github.com/user-attachments/assets/cef60296-9fde-4084-9cc9-f23af25af586)

## How it works

The plugin is configured in such a way that in order to be able to build the documentation with versioning, we need to
1. Have the latest docs version under `/docs`
2. Have the older documentation versions under `/docs/older`.

When those requirements are met, then when runing
```
gradle dokkaHtml
```
an html site with the documentation is generated which contains the older versions.
