### PR TITLE
Providing function overloads that receive String params instead of ZBytes

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
@@ -81,12 +81,18 @@ class Publisher internal constructor(
     fun priority() = qos.priority
 
     /** Performs a PUT operation on the specified [keyExpr] with the specified [payload]. */
-    fun put(payload: IntoZBytes, encoding: Encoding? = null, attachment: IntoZBytes? = null) = jniPublisher?.put(payload, encoding ?: this.encoding, attachment) ?: InvalidPublisherResult
+    fun put(payload: IntoZBytes, encoding: Encoding? = null, attachment: IntoZBytes? = null) =
+        jniPublisher?.put(payload, encoding ?: this.encoding, attachment) ?: InvalidPublisherResult
+
+    fun put(payload: String, encoding: Encoding? = null, attachment: String? = null) =
+        put(ZBytes.from(payload), encoding, attachment?.let { ZBytes.from(attachment) })
 
     /**
      * Performs a DELETE operation on the specified [keyExpr].
      */
     fun delete(attachment: IntoZBytes? = null) = jniPublisher?.delete(attachment) ?: InvalidPublisherResult
+
+    fun delete(attachment: String) = delete(ZBytes.from(attachment))
 
     /**
      * Returns `true` if the publisher is still running.

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
@@ -17,6 +17,7 @@ package io.zenoh.query
 import io.zenoh.annotations.Unstable
 import io.zenoh.bytes.Encoding
 import io.zenoh.bytes.IntoZBytes
+import io.zenoh.bytes.ZBytes
 import io.zenoh.exceptions.ZError
 import io.zenoh.handlers.Callback
 import io.zenoh.handlers.ChannelHandler
@@ -84,6 +85,14 @@ class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private v
         ) ?: throw ZError("Querier is not valid.")
     }
 
+    fun get(
+        channel: Channel<Reply>,
+        parameters: Parameters? = null,
+        payload: String,
+        encoding: Encoding? = null,
+        attachment: String? = null
+    ): Result<Channel<Reply>> = get(channel, parameters, ZBytes.from(payload), encoding, attachment?.let { ZBytes.from(it) })
+
     /**
      * Perform a get operation to the [keyExpr] from the Querier and handle the incoming replies
      * with the [callback] provided.
@@ -114,6 +123,14 @@ class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private v
         ) ?: throw ZError("Querier is not valid.")
     }
 
+    fun get(
+        callback: Callback<Reply>,
+        parameters: Parameters? = null,
+        payload: String,
+        encoding: Encoding? = null,
+        attachment: String? = null
+    ): Result<Unit> = get(callback, parameters, ZBytes.from(payload), encoding, attachment?.let { ZBytes.from(it) })
+
     /**
      * Perform a get operation to the [keyExpr] from the Querier and handle the incoming replies
      * with the [handler] provided.
@@ -143,6 +160,14 @@ class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private v
             encoding
         ) ?: throw ZError("Querier is not valid.")
     }
+
+    fun <R> get(
+        handler: Handler<Reply, R>,
+        parameters: Parameters? = null,
+        payload: String,
+        encoding: Encoding? = null,
+        attachment: String? = null
+    ): Result<R> = get(handler, parameters, ZBytes.from(payload), encoding, attachment?.let { ZBytes.from(it) })
 
     /**
      * Get the [QoS.congestionControl] of the querier.

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
@@ -79,6 +79,16 @@ class Query internal constructor(
         } ?: Result.failure(ZError("Query is invalid"))
     }
 
+    fun reply(
+        keyExpr: KeyExpr,
+        payload: String,
+        encoding: Encoding = Encoding.default(),
+        qos: QoS = QoS.default(),
+        timestamp: TimeStamp? = null,
+        attachment: String? = null
+    ): Result<Unit> =
+        reply(keyExpr, ZBytes.from(payload), encoding, qos, timestamp, attachment?.let { ZBytes.from(it) })
+
     /**
      * Reply error to the remote [Query].
      *
@@ -95,6 +105,10 @@ class Query internal constructor(
             result
         } ?: Result.failure(ZError("Query is invalid"))
     }
+
+
+    fun replyErr(error: String, encoding: Encoding = Encoding.default()): Result<Unit> =
+        replyErr(ZBytes.from(error), encoding)
 
     /**
      * Perform a delete reply operation to the remote [Query].
@@ -120,6 +134,13 @@ class Query internal constructor(
             result
         } ?: Result.failure(ZError("Query is invalid"))
     }
+
+    fun replyDel(
+        keyExpr: KeyExpr,
+        qos: QoS = QoS.default(),
+        timestamp: TimeStamp? = null,
+        attachment: String,
+    ): Result<Unit> = replyDel(keyExpr, qos, timestamp, ZBytes.from(attachment))
 
     override fun close() {
         jniQuery?.apply {


### PR DESCRIPTION
Allowing users to directly pass strings instead of having to convert them into ZBytes using ZBytes.from(string) each time.

This affects:
- session.get/put/delete
- publisher.put/delete
- query.reply/replyErr/replyDel
- querier.get