### PR TITLE
fix: always upload problem report

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -109,6 +109,7 @@ jobs:
           ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
       - name: "Upload gradle problems report"
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: problem-reports.zip

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -214,6 +214,7 @@ jobs:
           ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
       - name: "Upload gradle problems report"
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: problem-reports.zip


### PR DESCRIPTION
Otherwise in case of failure of the previous step, this one gets skipped.