### PR TITLE
Maven publication: splitting publication step on workflows

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -99,7 +99,17 @@ jobs:
         name: Gradle Publish Android Package to Maven Central repository
         run: |
           ./gradlew publishAndroidReleasePublicationToSonatypeRepository -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
-          ./gradlew closeAndReleaseSonatypeStagingRepository
+        env:
+          ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
+          ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
+          ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+
+      - if: ${{ inputs.maven_publish == true && inputs.snapshot == false }}
+        name: Close & Release Staging Repository
+        run: ./gradlew closeAndReleaseSonatypeStagingRepository -Pandroid=true
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
@@ -114,4 +124,3 @@ jobs:
         with:
           name: problem-reports.zip
           path: ${{ github.workspace }}/build/reports/problems/
-

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -204,7 +204,17 @@ jobs:
         name: Gradle Publish JVM Package to Maven Central repository
         run: |
           ./gradlew publishJvmPublicationToSonatypeRepository -PremotePublication=true ${{ env.PUB_MODE }}
-          ./gradlew closeAndReleaseSonatypeStagingRepository
+        env:
+          ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
+          ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
+          ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+
+      - if: ${{ inputs.maven_publish == true && inputs.snapshot == false }}
+        name: Close & Release Staging Repository
+        run: ./gradlew closeAndReleaseSonatypeStagingRepository
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}


### PR DESCRIPTION
Splitting "Gradle Publish JVM Package to Maven Central repository" with "Close & Release Staging Repository". Same for Android publications.