### PR TITLE
fix: publish to github and dokka after maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,14 +94,14 @@ jobs:
 
   publish-dokka:
     name: Publish documentation
-    needs: tag
+    needs: [tag, publish-android, publish-jvm]
     uses: ./.github/workflows/publish-dokka.yml
     with:
       live-run: ${{ inputs.live-run || false }}
       branch: ${{ needs.tag.outputs.branch }}
 
   publish-github:
-    needs: tag
+    needs: [tag, publish-android, publish-jvm]
     runs-on: macos-latest
     steps:
       - uses: eclipse-zenoh/ci/publish-crates-github@main


### PR DESCRIPTION
Only publish the github release and dokka documentation after maven publication succeeds. Otherwise if it fails, makes it harder to cleanup the failed release.