### PR TITLE
Examples fat JARs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
         classpath("org.mozilla.rust-android-gradle:plugin:0.9.6")
         classpath("com.android.tools.build:gradle:7.4.2")
+        classpath("com.gradleup.shadow:shadow-gradle-plugin:9.0.0-beta6")
     }
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,63 +4,61 @@
 
 ## Start instructions
 
+For running the examples, there are two approaches. Either you run the gradle example task with the syntax `gradle <example> --args="<arguments>"` or you can build fat JARs the examples through the task `gradle buildExamples`.
+
+While both are valid, in this document we'll follow the second approach; when running `gradle buildExamples`, all the JARs will be located under `/examples/build/libs`, which can later be executed
+
 ```bash
-gradle <example> --args="<arguments>"
+java -jar <Example>.jar <arguments>
 ```
 
 for instance
 
 ```bash
-gradle ZPub --args="-h"
+java -jar ZPub.jar -h
 ```
 
 will return
 
 ```bash
-> Task :examples:ZPub
 Usage: zpub [<options>]
 
   Zenoh Pub example
 
 Options:
-  -k, --key=<key>             The key expression to write to [default:
-                              demo/example/zenoh-kotlin-pub]
-  -c, --config=<config>       A configuration file.
-  -e, --connect=<connect>...  Endpoints to connect to.
-  -l, --listen=<listen>...    Endpoints to listen on.
-  -m, --mode=<mode>           The session mode. Default: peer. Possible values:
-                              [peer, client, router]
-  -v, --value=<value>         The value to write. [Default: "Pub from Kotlin!"]
-  -a, --attach=<attach>       The attachments to add to each put. The key-value
-                              pairs are &-separated, and = serves as the
-                              separator between key and value.
-  --no-multicast-scouting     Disable the multicast-based scouting mechanism.
-  -h, --help                  Show this message and exit
-
+  -k, --key=<key>          The key expression to write to [default: demo/example/zenoh-kotlin-pub]
+  -c, --config=<config>    A configuration file.
+  -e, --connect=<connect>  Endpoints to connect to.
+  -l, --listen=<listen>    Endpoints to listen on.
+  -m, --mode=<mode>        The session mode. Default: peer. Possible values: [peer, client, router]
+  -v, --value=<value>      The value to write. [Default: "Pub from Kotlin!"]
+  -a, --attach=<attach>    The attachments to add to each put. The key-value pairs are &-separated, and = serves as the separator between key and value.
+  --no-multicast-scouting  Disable the multicast-based scouting mechanism.
+  -h, --help               Show this message and exit
 ```
 
 The connect and listen parameters (that are common to all the examples) accept multiple repeated inputs.
 For instance:
 
 ```bash
-gradle ZPub --args="-l tcp/localhost:7447 -l tcp/localhost:7448 -l tcp/localhost:7449"
+java -jar ZPub.jar -l tcp/localhost:7447 -l tcp/localhost:7448 -l tcp/localhost:7449
 ```
 
 There is the possibility to provide a Zenoh config file as follows
 
 ```bash
-gradle ZPub --args="-c path/to/config.json5"
+java -jar ZPub.jar -c path/to/config.json5
 ```
 
 In that case, any other provided configuration parameters through the command line interface will not be taken into consideration.
 
-One last comment regarding Zenoh logging for the examples, remember it can be enabled through the environment variable `RUST_LOG` as follows:
+One last comment regarding Zenoh logging for the examples, logs from the native library can be enabled through the environment variable `RUST_LOG` as follows:
 
 ```bash
-RUST_LOG=<level> gradle ZPub
+RUST_LOG=<level> java -jar ZPub.jar
 ```
 
-where `<level>` can be either `info`, `trace`, `debug`, `warn` or `error`.
+where `<level>` is the log filter (for instance `debug`, `warn`, `error`... (see the [Rust documentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging))).
 
 ----
 
@@ -74,13 +72,13 @@ The path/value will be received by all matching subscribers, for instance the [Z
 Usage:
 
 ```bash
-gradle ZPub
+java -jar ZPub.jar
 ```
 
 or
 
 ```bash
-gradle ZPub --args="-k demo/example/test -v 'hello world'"
+java -jar ZPub.jar -k demo/example/test -v "hello world"
 ```
 
 ### ZSub
@@ -92,13 +90,13 @@ the subscriber's key expression, and will print this notification.
 Usage:
 
 ```bash
-gradle ZSub
+java -jar ZSub.jar
 ```
 
 or
 
 ```bash
-gradle ZSub --args="-k demo/example/test"
+java -jar ZSub.jar -k demo/example/test
 ```
 
 ### ZGet
@@ -108,13 +106,13 @@ The queryables with a matching path or selector (for instance [ZQueryable](#zque
 will receive this query and reply with paths/values that will be received by the query callback.
 
 ```bash
-gradle ZGet
+java -jar ZGet.jar
 ```
 
 or
 
 ```bash
-gradle ZGet --args="-s demo/example/get"
+java -jar ZGet.jar -s demo/example/get
 ```
 
 ### ZPut
@@ -125,13 +123,13 @@ The path/value will be received by all matching subscribers, for instance the [Z
 Usage:
 
 ```bash
-gradle ZPut
+java -jar ZPut.jar
 ```
 
 or
 
 ```bash
-gradle ZPut --args="-k demo/example/put -v 'Put from Kotlin!'"
+java -jar ZPut.jar -k demo/example/put -v 'Put from Kotlin!'
 ```
 
 ### ZDelete
@@ -141,13 +139,13 @@ Performs a Delete operation into a path/value into Zenoh.
 Usage:
 
 ```bash
-gradle ZDelete
+java -jar ZDelete.jar
 ```
 
 or
 
 ```bash
-gradle ZDelete --args="-k demo/example/delete"
+java -jar ZDelete.jar -k demo/example/delete
 ```
 
 ### ZQueryable
@@ -159,13 +157,13 @@ with a selector that matches the key expression, and will return a value to the 
 Usage:
 
 ```bash
-gradle ZQueryable
+java -jar ZQueryable.jar
 ```
 
 or
 
 ```bash
-gradle ZQueryable --args="-k demo/example/query"
+java -jar ZQueryable.jar -k demo/example/query
 ```
 
 ### ZPubThr & ZSubThr
@@ -177,11 +175,63 @@ put operations and a subscriber receiving notifications of those puts.
 Subscriber usage:
 
 ```bash
-gradle ZSubThr
+java -jar ZSubThr.jar
 ```
 
 Publisher usage:
 
 ```bash
-gradle ZPubThr <payload_size>
+java -jar ZPubThr.jar <payload_size>
+```
+
+### ZPing & ZPong
+
+Latency tests
+
+```bash
+java -jar ZPing.jar
+```
+
+```bash
+java -jar ZPong.jar
+```
+
+### ZScout
+
+A scouting example. Will show information from other nodes in the Zenoh network.
+
+```bash
+java -jar ZScout.jar
+```
+
+### Liveliness examples
+
+#### ZLiveliness
+
+The ZLiveliness example, it just announces itself to the Zenoh network by default to the key expression `group1/zenoh-kotlin`.
+
+Usage:
+
+```bash
+java -jar ZLiveliness
+```
+
+It can be used along with the following liveliness examples:
+
+#### ZGetLiveliness
+
+Gets the liveliness tokens, by default to `group1/zenoh-kotlin`.
+
+Usage:
+
+```bash
+java -jar ZGetLiveliness
+```
+
+#### ZSubLiveliness
+
+Subscribes to liveliness events:
+
+```bash
+java -jar ZSubLiveliness
 ```

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -12,9 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
+    id("com.gradleup.shadow")
 }
 
 kotlin {
@@ -49,6 +52,29 @@ tasks {
         "ZSubLiveliness",
         "ZSubThr"
     )
+
+    examples.forEach { example ->
+        register<ShadowJar>("${example}Jar") {
+            group = "build"
+            description = "Build a fat JAR for the $example example"
+            from(sourceSets["main"].output)
+            manifest {
+                attributes["Main-Class"] = "io.zenoh.${example}Kt"
+            }
+            configurations.empty()
+            configurations.add(project.configurations.getByName("runtimeClasspath"))
+
+            archiveBaseName.set(example)
+            archiveVersion.set("")
+            archiveClassifier.set("")
+        }
+    }
+
+    register("buildExamples") {
+        group = "build"
+        description = "Build all fat JARs for the Zenoh Kotlin examples"
+        dependsOn(examples.map { "${it}Jar" })
+    }
 
     examples.forEach { example ->
         register(example, JavaExec::class) {


### PR DESCRIPTION
Adding tasks for creating executable jar's for the examples. The gradle task `buildExamples` will output fat jar's for each of the examples, which can be later run with

```
java -jar <Example>.jar
```

Also the README is updated.