### PR TITLE
Maven publication: adding javadoc jar to maven publication

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -173,6 +173,13 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26
+          add-to-path: false
+          link-to-sdk: true
+
       - name: Gradle Wrapper
         run: |
           gradle wrapper
@@ -195,7 +202,7 @@ jobs:
       - if: ${{ inputs.maven_publish == true }}
         name: Gradle Publish JVM Package to Maven Central repository
         run: |
-          ./gradlew publishJvmPublicationToSonatypeRepository ${{ env.RELEASE }} --info -PremotePublication=true ${{ env.PUB_MODE }}
+          ./gradlew publishJvmPublicationToSonatypeRepository ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
@@ -206,7 +213,7 @@ jobs:
 
       - if: ${{ inputs.github_publish == true }}
         name: Gradle Publish JVM Package to GitHub packages repository
-        run: ./gradlew publishJvmPublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true ${{ env.PUB_MODE }}
+        run: ./gradlew publishJvmPublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -92,11 +92,19 @@ kotlin {
         }
     }
 
+    val javadocJar by tasks.registering(Jar::class) {
+        dependsOn("dokkaHtml")
+        archiveClassifier.set("javadoc")
+        from("${buildDir}/dokka/html")
+    }
+
     publishing {
         publications.withType<MavenPublication> {
             groupId = "org.eclipse.zenoh"
             artifactId = "zenoh-kotlin"
             version = rootProject.version.toString()
+
+            artifact(javadocJar)
 
             pom {
                 name.set("Zenoh Kotlin")


### PR DESCRIPTION
Non snapshot packages published to maven central require among other things to contain a javadoc JAR internally.