### PR TITLE
Upgrade Dokka to 2.0.0

### DIFF
--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -25,15 +25,8 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r26
-          add-to-path: false
-          link-to-sdk: true
-
       - name: Build doc
-        run: gradle -Pandroid=true dokkaHtml
+        run: gradle dokkaHtml
 
       - name: Deploy doc
         if: ${{ inputs.live-run || false }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -173,13 +173,6 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r26
-          add-to-path: false
-          link-to-sdk: true
-
       - name: Gradle Wrapper
         run: |
           gradle wrapper
@@ -202,7 +195,7 @@ jobs:
       - if: ${{ inputs.maven_publish == true }}
         name: Gradle Publish JVM Package to Maven Central repository
         run: |
-          ./gradlew publishJvmPublicationToSonatypeRepository ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
+          ./gradlew publishJvmPublicationToSonatypeRepository ${{ env.RELEASE }} --info -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
@@ -213,7 +206,7 @@ jobs:
 
       - if: ${{ inputs.github_publish == true }}
         name: Gradle Publish JVM Package to GitHub packages repository
-        run: ./gradlew publishJvmPublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
+        run: ./gradlew publishJvmPublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true ${{ env.PUB_MODE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 .gradle
 build/
 examples/build
-gradle.properties
 gradle/
 gradlew
 gradlew.bat

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.10" apply false
     id("org.jetbrains.kotlin.multiplatform") version "1.9.0" apply false
     id("org.mozilla.rust-android-gradle.rust-android") version "0.9.6" apply false
-    id("org.jetbrains.dokka") version "1.8.20" apply false
+    id("org.jetbrains.dokka") version "2.0.0" apply false
     id("com.adarshr.test-logger") version "3.2.0" apply false
     kotlin("plugin.serialization") version "1.9.0" apply false
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/zenoh-kotlin/build.gradle.kts
+++ b/zenoh-kotlin/build.gradle.kts
@@ -93,7 +93,7 @@ kotlin {
     }
 
     val javadocJar by tasks.registering(Jar::class) {
-        dependsOn("dokkaHtml")
+        dependsOn("dokkaGeneratePublicationHtml")
         archiveClassifier.set("javadoc")
         from("${buildDir}/dokka/html")
     }


### PR DESCRIPTION
This fixes the workflow errors when attempting to build the documentation without enabling android.