### PR TITLE
fix: remove github maven package publication

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -12,19 +12,11 @@ on:
         description: Target branch
         type: string
         required: false
-      github_publish:
-        type: boolean
-        required: false
-        default: true
       maven_publish:
         type: boolean
         required: false
         default: true
   workflow_dispatch:
-    inputs:
-      github_publish:
-        description: 'Publish to github packages'
-        default: true
       maven_publish:
         description: 'Publish to Maven Central'
         default: true
@@ -94,16 +86,6 @@ jobs:
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
-          ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
-          ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-
-      - if: ${{ inputs.github_publish == true }}
-        name: Gradle Publish Android Package to GitHub packages repository
-        run: ./gradlew publishAndroidReleasePublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
           ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
           ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -12,19 +12,12 @@ on:
         description: Target branch
         type: string
         required: false
-      github_publish:
-        type: boolean
-        required: false
-        default: true
       maven_publish:
         type: boolean
         required: false
         default: true
   workflow_dispatch:
     inputs:
-      github_publish:
-        description: 'Publish to github packages'
-        default: "true"
       maven_publish:
         description: 'Publish to Maven Central'
         default: "true"
@@ -199,16 +192,6 @@ jobs:
         env:
           ORG_OSSRH_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           ORG_OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
-          ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
-          ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          ORG_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-
-      - if: ${{ inputs.github_publish == true }}
-        name: Gradle Publish JVM Package to GitHub packages repository
-        run: ./gradlew publishJvmPublicationToGithubPackagesRepository ${{ env.RELEASE }} --info -PremotePublication=true ${{ env.PUB_MODE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GPG_KEY_ID: ${{ secrets.ORG_GPG_KEY_ID }}
           ORG_GPG_SUBKEY_ID: ${{ secrets.ORG_GPG_SUBKEY_ID }}
           ORG_GPG_PRIVATE_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
Now that publication to maven central is working, we don't need to publish to github packages anymore and this workflow only gets in the way.