### PR TITLE
Fix bug: dropping publishers when losing references to them

### DIFF
--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
@@ -118,4 +118,8 @@ class Publisher internal constructor(
         jniPublisher?.close()
         jniPublisher = null
     }
+
+    protected fun finalize() {
+        undeclare()
+    }
 }


### PR DESCRIPTION
Issue: when dropping a Publisher it will remain alive (consuming resources) until the session is closed because of the internal reference in the Session.
The interest of having an internal list of the session declarations inside a session is to clean them up when closing the session.

Fix: for queriers and publishers we store them as weak references which won't prevent their garbage collection.