### PR TITLE
ci: update workflow to use latest runners

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -34,13 +34,13 @@ jobs:
           - {
               target: x86_64-unknown-linux-gnu,
               arch: amd64,
-              os: ubuntu-24.04,
+              os: ubuntu-latest,
               build-cmd: "cargo",
             }
           - {
               target: aarch64-unknown-linux-gnu,
               arch: arm64,
-              os: ubuntu-24.04,
+              os: ubuntu-latest,
               build-cmd: "cross",
             }
           - {
@@ -58,13 +58,13 @@ jobs:
           - {
               target: x86_64-pc-windows-msvc,
               arch: win64,
-              os: windows-2019,
+              os: windows-latest,
               build-cmd: "cargo",
             }
           - {
             target: aarch64-pc-windows-msvc,
             arch: arm64,
-            os: windows-2019,
+            os: windows-latest,
             build-cmd: "cargo",
           }
     steps:


### PR DESCRIPTION
More specifically the windows-2019 got deprecated which causes the release workflow to be cancelled.