### PR TITLE
[ZEN-587] Change `replier_id` type to `EntityGlobalId`

### DIFF
--- a/zenoh-jni/Cargo.lock
+++ b/zenoh-jni/Cargo.lock
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "ahash",
 ]
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "aes",
  "hmac",
@@ -3197,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "flume 0.11.0",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3317,7 +3317,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "libc",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "nix",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "git-version",
  "libloading",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "const_format",
  "rand",
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "anyhow",
 ]
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "futures",
  "tokio",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.4.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#5d4beac71f7849ea800568e6761af33ba49675c6"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1c8ee0e1ef1c19fbf4ecf6c7abc4f262b7a5801d"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/config/ZenohId.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/config/ZenohId.kt
@@ -38,3 +38,11 @@ data class ZenohId internal constructor(internal val bytes: ByteArray) {
         return bytes.contentHashCode()
     }
 }
+
+/**
+ * The global unique id of a Zenoh entity.
+ * Contains two fields:
+ * - zid: the global unique id of a Zenoh peer.
+ * - eid: *unsigned* unique identifier of the entity within the Zenoh peer.
+ */
+data class EntityGlobalId internal constructor(val zid: ZenohId, val eid: UInt)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNILiveliness.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNILiveliness.kt
@@ -16,6 +16,7 @@ package io.zenoh.jni
 
 import io.zenoh.bytes.Encoding
 import io.zenoh.bytes.into
+import io.zenoh.config.EntityGlobalId
 import io.zenoh.config.ZenohId
 import io.zenoh.handlers.Callback
 import io.zenoh.jni.callbacks.JNIGetCallback
@@ -45,7 +46,8 @@ internal object JNILiveliness {
         onClose: () -> Unit
     ): Result<R> = runCatching {
         val getCallback = JNIGetCallback {
-                replierId: ByteArray?,
+                replierZid: ByteArray?,
+                replierEid: Int,
                 success: Boolean,
                 keyExpr2: String?,
                 payload: ByteArray,
@@ -71,10 +73,10 @@ internal object JNILiveliness {
                     QoS(CongestionControl.fromInt(congestionControl), Priority.fromInt(priority), express),
                     attachmentBytes?.into()
                 )
-                reply = Reply(replierId?.let { ZenohId(it) }, Result.success(sample))
+                reply = Reply(replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.success(sample))
             } else {
                 reply = Reply(
-                    replierId?.let { ZenohId(it) }, Result.failure(
+                    replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.failure(
                         ReplyError(
                             payload.into(),
                             Encoding(encodingId, schema = encodingSchema)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuerier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNIQuerier.kt
@@ -17,6 +17,7 @@ package io.zenoh.jni
 import io.zenoh.bytes.Encoding
 import io.zenoh.bytes.IntoZBytes
 import io.zenoh.bytes.into
+import io.zenoh.config.EntityGlobalId
 import io.zenoh.config.ZenohId
 import io.zenoh.exceptions.ZError
 import io.zenoh.handlers.Callback
@@ -46,7 +47,8 @@ internal class JNIQuerier(val ptr: Long) {
         encoding: Encoding?
     ): Result<R> = runCatching {
         val getCallback = JNIGetCallback {
-                replierId: ByteArray?,
+                replierZid: ByteArray?,
+                replierEid: Int,
                 success: Boolean,
                 keyExpr: String?,
                 payload: ByteArray,
@@ -72,10 +74,10 @@ internal class JNIQuerier(val ptr: Long) {
                     QoS(CongestionControl.fromInt(congestionControl), Priority.fromInt(priority), express),
                     attachmentBytes?.into()
                 )
-                reply = Reply(replierId?.let { ZenohId(it) }, Result.success(sample))
+                reply = Reply(replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.success(sample))
             } else {
                 reply = Reply(
-                    replierId?.let { ZenohId(it) }, Result.failure(
+                    replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.failure(
                         ReplyError(
                             payload.into(),
                             Encoding(encodingId, schema = encodingSchema)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/JNISession.kt
@@ -28,6 +28,7 @@ import io.zenoh.config.ZenohId
 import io.zenoh.bytes.into
 import io.zenoh.Config
 import io.zenoh.annotations.Unstable
+import io.zenoh.config.EntityGlobalId
 import io.zenoh.pubsub.AdvancedSubscriber
 import io.zenoh.pubsub.AdvancedPublisher
 import io.zenoh.pubsub.Delete
@@ -268,7 +269,8 @@ internal class JNISession {
         qos: QoS
     ): Result<R> = runCatching {
         val getCallback = JNIGetCallback {
-                replierId: ByteArray?,
+                replierZid: ByteArray?,
+                replierEid: Int,
                 success: Boolean,
                 keyExpr: String?,
                 payload: ByteArray,
@@ -294,10 +296,10 @@ internal class JNISession {
                     QoS(CongestionControl.fromInt(congestionControl), Priority.fromInt(priority), express),
                     attachmentBytes?.into()
                 )
-                reply = Reply(replierId?.let { ZenohId(it) }, Result.success(sample))
+                reply = Reply(replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.success(sample))
             } else {
                 reply = Reply(
-                    replierId?.let { ZenohId(it) }, Result.failure(
+                    replierZid?.let { EntityGlobalId(ZenohId(it), replierEid.toUInt()) }, Result.failure(
                         ReplyError(
                             payload.into(),
                             Encoding(encodingId, schema = encodingSchema)

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/jni/callbacks/JNIGetCallback.kt
@@ -17,7 +17,8 @@ package io.zenoh.jni.callbacks
 internal fun interface JNIGetCallback {
 
     fun run(
-        replierId: ByteArray?,
+        replierZid: ByteArray?,
+        replierEid: Int,
         success: Boolean,
         keyExpr: String?,
         payload: ByteArray,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Reply.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Reply.kt
@@ -15,8 +15,8 @@
 package io.zenoh.query
 
 import io.zenoh.ZenohType
+import io.zenoh.config.EntityGlobalId
 import io.zenoh.sample.Sample
-import io.zenoh.config.ZenohId
 
 /**
  * Class to represent a Zenoh Reply to a get query and to a remote [Query].
@@ -43,4 +43,4 @@ import io.zenoh.config.ZenohId
  * @property replierId: unique ID identifying the replier, may be null in case the network cannot provide it
  *   (@see https://github.com/eclipse-zenoh/zenoh/issues/709#issuecomment-2202763630).
  */
-data class Reply(val replierId: ZenohId?, val result: Result<Sample>) : ZenohType
+data class Reply(val replierId: EntityGlobalId?, val result: Result<Sample>) : ZenohType


### PR DESCRIPTION
Depends on https://github.com/eclipse-zenoh/zenoh/pull/2052

This is a breaking change.