### PR TITLE
fix(jni): pass native pointers across the JNI boundary as `jlong` (32-bit ABI)

### DIFF
--- a/zenoh-jni/src/config.rs
+++ b/zenoh-jni/src/config.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::{ptr::null, sync::Arc};
 
 use jni::{
@@ -127,9 +128,10 @@ pub extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_loadYamlConfigViaJN
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_getJsonViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    cfg_ptr: *const Config,
+    cfg_ptr: jlong,
     key: JString,
 ) -> jstring {
+    let cfg_ptr = cfg_ptr as *const Config;
     let arc_cfg: Arc<Config> = Arc::from_raw(cfg_ptr);
     let result = || -> ZResult<jstring> {
         let key = decode_string(&mut env, &key)?;
@@ -152,10 +154,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_getJsonViaJN
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_insertJson5ViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    cfg_ptr: *const Config,
+    cfg_ptr: jlong,
     key: JString,
     value: JString,
 ) {
+    let cfg_ptr = cfg_ptr as *const Config;
     || -> ZResult<()> {
         let key = decode_string(&mut env, &key)?;
         let value = decode_string(&mut env, &value)?;
@@ -179,7 +182,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_insertJson5V
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIConfig_00024Companion_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    config_ptr: *const Config,
+    config_ptr: jlong,
 ) {
+    let config_ptr = config_ptr as *const Config;
     Arc::from_raw(config_ptr);
 }

--- a/zenoh-jni/src/ext/advanced_publisher.rs
+++ b/zenoh-jni/src/ext/advanced_publisher.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::objects::JValue;
@@ -113,11 +114,12 @@ impl<'a> SetJniMatchingStatusCallback for MatchingListenerBuilder<'a, DefaultHan
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_declareMatchingListenerViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_publisher_ptr: *const AdvancedPublisher,
+    advanced_publisher_ptr: jlong,
 
     callback: JObject,
     on_close: JObject,
 ) -> *const MatchingListener<()> {
+    let advanced_publisher_ptr = advanced_publisher_ptr as *const AdvancedPublisher;
     let advanced_publisher = OwnedObject::from_raw(advanced_publisher_ptr);
 
     || -> ZResult<*const MatchingListener<()>> {
@@ -169,11 +171,12 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_declareMatchingL
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_declareBackgroundMatchingListenerViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_publisher_ptr: *const AdvancedPublisher,
+    advanced_publisher_ptr: jlong,
 
     callback: JObject,
     on_close: JObject,
 ) {
+    let advanced_publisher_ptr = advanced_publisher_ptr as *const AdvancedPublisher;
     let advanced_publisher = OwnedObject::from_raw(advanced_publisher_ptr);
 
     || -> ZResult<()> {
@@ -223,8 +226,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_declareBackgroun
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_getMatchingStatusViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_publisher_ptr: *const AdvancedPublisher,
+    advanced_publisher_ptr: jlong,
 ) -> jboolean {
+    let advanced_publisher_ptr = advanced_publisher_ptr as *const AdvancedPublisher;
     use crate::errors::ZError;
 
     let advanced_publisher = OwnedObject::from_raw(advanced_publisher_ptr);
@@ -265,8 +269,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_putViaJNI(
     encoding_id: jint,
     encoding_schema: /*nullable*/ JString,
     attachment: /*nullable*/ JByteArray,
-    publisher_ptr: *const AdvancedPublisher<'static>,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const AdvancedPublisher<'static>;
     let publisher = OwnedObject::from_raw(publisher_ptr);
     let _ = || -> ZResult<()> {
         let payload = decode_byte_array(&env, payload)?;
@@ -302,8 +307,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_deleteViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     attachment: /*nullable*/ JByteArray,
-    publisher_ptr: *const AdvancedPublisher<'static>,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const AdvancedPublisher<'static>;
     let publisher = OwnedObject::from_raw(publisher_ptr);
     let _ = || -> ZResult<()> {
         let mut delete = publisher.delete();
@@ -333,7 +339,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_deleteViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedPublisher_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    publisher_ptr: *const AdvancedPublisher,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const AdvancedPublisher;
     Arc::from_raw(publisher_ptr);
 }

--- a/zenoh-jni/src/ext/advanced_subscriber.rs
+++ b/zenoh-jni/src/ext/advanced_subscriber.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::sys::jboolean;
@@ -126,11 +127,12 @@ impl<'a> SetJniSampleMissListenerCallback for SampleMissListenerBuilder<'a, Defa
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareDetectPublishersSubscriberViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_subscriber_ptr: *const AdvancedSubscriber<()>,
+    advanced_subscriber_ptr: jlong,
     history: jboolean,
     callback: JObject,
     on_close: JObject,
 ) -> *const Subscriber<()> {
+    let advanced_subscriber_ptr = advanced_subscriber_ptr as *const AdvancedSubscriber<()>;
     let advanced_subscriber = OwnedObject::from_raw(advanced_subscriber_ptr);
 
     || -> ZResult<*const Subscriber<()>> {
@@ -182,11 +184,12 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareDetectPu
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareBackgroundDetectPublishersSubscriberViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_subscriber_ptr: *const AdvancedSubscriber<()>,
+    advanced_subscriber_ptr: jlong,
     history: jboolean,
     callback: JObject,
     on_close: JObject,
 ) {
+    let advanced_subscriber_ptr = advanced_subscriber_ptr as *const AdvancedSubscriber<()>;
     let advanced_subscriber = OwnedObject::from_raw(advanced_subscriber_ptr);
 
     || -> ZResult<()> {
@@ -246,11 +249,12 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareBackgrou
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareSampleMissListenerViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_subscriber_ptr: *const AdvancedSubscriber<()>,
+    advanced_subscriber_ptr: jlong,
 
     callback: JObject,
     on_close: JObject,
 ) -> *const SampleMissListener<()> {
+    let advanced_subscriber_ptr = advanced_subscriber_ptr as *const AdvancedSubscriber<()>;
     let advanced_subscriber = OwnedObject::from_raw(advanced_subscriber_ptr);
 
     || -> ZResult<*const SampleMissListener<()>> {
@@ -304,11 +308,12 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareSampleMi
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareBackgroundSampleMissListenerViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    advanced_subscriber_ptr: *const AdvancedSubscriber<()>,
+    advanced_subscriber_ptr: jlong,
 
     callback: JObject,
     on_close: JObject,
 ) {
+    let advanced_subscriber_ptr = advanced_subscriber_ptr as *const AdvancedSubscriber<()>;
     let advanced_subscriber = OwnedObject::from_raw(advanced_subscriber_ptr);
 
     || -> ZResult<()> {
@@ -353,7 +358,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_declareBackgrou
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIAdvancedSubscriber_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    subscriber_ptr: *const AdvancedSubscriber<()>,
+    subscriber_ptr: jlong,
 ) {
+    let subscriber_ptr = subscriber_ptr as *const AdvancedSubscriber<()>;
     Arc::from_raw(subscriber_ptr);
 }

--- a/zenoh-jni/src/ext/matching_listener.rs
+++ b/zenoh-jni/src/ext/matching_listener.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{objects::JClass, JNIEnv};
@@ -35,7 +36,8 @@ use zenoh::matching::MatchingListener;
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIMatchingListener_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    matching_listener_ptr: *const MatchingListener<()>,
+    matching_listener_ptr: jlong,
 ) {
+    let matching_listener_ptr = matching_listener_ptr as *const MatchingListener<()>;
     Arc::from_raw(matching_listener_ptr);
 }

--- a/zenoh-jni/src/ext/sample_miss_listener.rs
+++ b/zenoh-jni/src/ext/sample_miss_listener.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{objects::JClass, JNIEnv};
@@ -35,7 +36,8 @@ use zenoh_ext::SampleMissListener;
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNISampleMissListener_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    sample_miss_listener_ptr: *const SampleMissListener<()>,
+    sample_miss_listener_ptr: jlong,
 ) {
+    let sample_miss_listener_ptr = sample_miss_listener_ptr as *const SampleMissListener<()>;
     Arc::from_raw(sample_miss_listener_ptr);
 }

--- a/zenoh-jni/src/key_expr.rs
+++ b/zenoh-jni/src/key_expr.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -94,11 +95,13 @@ pub extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_autocanonizeViaJNI
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_intersectsViaJNI(
     mut env: JNIEnv,
     _: JClass,
-    key_expr_ptr_1: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_1: jlong,
     key_expr_str_1: JString,
-    key_expr_ptr_2: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_2: jlong,
     key_expr_str_2: JString,
 ) -> jboolean {
+    let key_expr_ptr_1 = key_expr_ptr_1 as *const KeyExpr<'static>;
+    let key_expr_ptr_2 = key_expr_ptr_2 as *const KeyExpr<'static>;
     || -> ZResult<jboolean> {
         let key_expr_1 = process_kotlin_key_expr(&mut env, &key_expr_str_1, key_expr_ptr_1)?;
         let key_expr_2 = process_kotlin_key_expr(&mut env, &key_expr_str_2, key_expr_ptr_2)?;
@@ -130,11 +133,13 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_intersectsV
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_includesViaJNI(
     mut env: JNIEnv,
     _: JClass,
-    key_expr_ptr_1: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_1: jlong,
     key_expr_str_1: JString,
-    key_expr_ptr_2: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_2: jlong,
     key_expr_str_2: JString,
 ) -> jboolean {
+    let key_expr_ptr_1 = key_expr_ptr_1 as *const KeyExpr<'static>;
+    let key_expr_ptr_2 = key_expr_ptr_2 as *const KeyExpr<'static>;
     || -> ZResult<jboolean> {
         let key_expr_1 = process_kotlin_key_expr(&mut env, &key_expr_str_1, key_expr_ptr_1)?;
         let key_expr_2 = process_kotlin_key_expr(&mut env, &key_expr_str_2, key_expr_ptr_2)?;
@@ -167,11 +172,13 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_includesVia
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_relationToViaJNI(
     mut env: JNIEnv,
     _: JClass,
-    key_expr_ptr_1: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_1: jlong,
     key_expr_str_1: JString,
-    key_expr_ptr_2: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_2: jlong,
     key_expr_str_2: JString,
 ) -> jint {
+    let key_expr_ptr_1 = key_expr_ptr_1 as *const KeyExpr<'static>;
+    let key_expr_ptr_2 = key_expr_ptr_2 as *const KeyExpr<'static>;
     || -> ZResult<jint> {
         let key_expr_1 = process_kotlin_key_expr(&mut env, &key_expr_str_1, key_expr_ptr_1)?;
         let key_expr_2 = process_kotlin_key_expr(&mut env, &key_expr_str_2, key_expr_ptr_2)?;
@@ -203,10 +210,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_relationToV
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_joinViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr_1: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_1: jlong,
     key_expr_str_1: JString,
     key_expr_2: JString,
 ) -> jstring {
+    let key_expr_ptr_1 = key_expr_ptr_1 as *const KeyExpr<'static>;
     || -> ZResult<jstring> {
         let key_expr_1 = process_kotlin_key_expr(&mut env, &key_expr_str_1, key_expr_ptr_1)?;
         let key_expr_2_str = decode_string(&mut env, &key_expr_2)?;
@@ -243,10 +251,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_joinViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_concatViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr_1: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr_1: jlong,
     key_expr_str_1: JString,
     key_expr_2: JString,
 ) -> jstring {
+    let key_expr_ptr_1 = key_expr_ptr_1 as *const KeyExpr<'static>;
     || -> ZResult<jstring> {
         let key_expr_1 = process_kotlin_key_expr(&mut env, &key_expr_str_1, key_expr_ptr_1)?;
         let key_expr_2_str = decode_string(&mut env, &key_expr_2)?;
@@ -280,8 +289,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_00024Companion_concatViaJN
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIKeyExpr_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    key_expr_ptr: *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
 ) {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     Arc::from_raw(key_expr_ptr);
 }
 

--- a/zenoh-jni/src/liveliness.rs
+++ b/zenoh-jni/src/liveliness.rs
@@ -41,13 +41,15 @@ use crate::{
 pub extern "C" fn Java_io_zenoh_jni_JNILiveliness_getViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    session_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     callback: JObject,
     timeout_ms: jlong,
     on_close: JObject,
 ) {
+    let session_ptr = session_ptr as *const Session;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let session = unsafe { OwnedObject::from_raw(session_ptr) };
     let _ = || -> ZResult<()> {
         let key_expr = unsafe { process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr) }?;
@@ -104,10 +106,12 @@ pub extern "C" fn Java_io_zenoh_jni_JNILiveliness_getViaJNI(
 pub extern "C" fn Java_io_zenoh_jni_JNILiveliness_declareTokenViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    session_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
 ) -> *const LivelinessToken {
+    let session_ptr = session_ptr as *const Session;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let session = unsafe { OwnedObject::from_raw(session_ptr) };
     || -> ZResult<*const LivelinessToken> {
         let key_expr = unsafe { process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr) }?;
@@ -130,8 +134,9 @@ pub extern "C" fn Java_io_zenoh_jni_JNILiveliness_declareTokenViaJNI(
 pub extern "C" fn Java_io_zenoh_jni_JNILivelinessToken_00024Companion_undeclareViaJNI(
     _env: JNIEnv,
     _: JClass,
-    token_ptr: *const LivelinessToken,
+    token_ptr: jlong,
 ) {
+    let token_ptr = token_ptr as *const LivelinessToken;
     unsafe { Arc::from_raw(token_ptr) };
 }
 
@@ -140,13 +145,15 @@ pub extern "C" fn Java_io_zenoh_jni_JNILivelinessToken_00024Companion_undeclareV
 pub extern "C" fn Java_io_zenoh_jni_JNILiveliness_declareSubscriberViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    session_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     callback: JObject,
     history: jboolean,
     on_close: JObject,
 ) -> *const Subscriber<()> {
+    let session_ptr = session_ptr as *const Session;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let session = unsafe { OwnedObject::from_raw(session_ptr) };
     || -> ZResult<*const Subscriber<()>> {
         let key_expr = unsafe { process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)? };

--- a/zenoh-jni/src/publisher.rs
+++ b/zenoh-jni/src/publisher.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{
@@ -54,8 +55,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_putViaJNI(
     encoding_id: jint,
     encoding_schema: /*nullable*/ JString,
     attachment: /*nullable*/ JByteArray,
-    publisher_ptr: *const Publisher<'static>,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const Publisher<'static>;
     let publisher = Arc::from_raw(publisher_ptr);
     let _ = || -> ZResult<()> {
         let payload = decode_byte_array(&env, payload)?;
@@ -92,8 +94,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_deleteViaJNI(
     mut env: JNIEnv,
     _class: JClass,
     attachment: /*nullable*/ JByteArray,
-    publisher_ptr: *const Publisher<'static>,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const Publisher<'static>;
     let publisher = Arc::from_raw(publisher_ptr);
     let _ = || -> ZResult<()> {
         let mut delete = publisher.delete();
@@ -124,7 +127,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_deleteViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIPublisher_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    publisher_ptr: *const Publisher,
+    publisher_ptr: jlong,
 ) {
+    let publisher_ptr = publisher_ptr as *const Publisher;
     Arc::from_raw(publisher_ptr);
 }

--- a/zenoh-jni/src/querier.rs
+++ b/zenoh-jni/src/querier.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{
@@ -58,8 +59,8 @@ use crate::{
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    querier_ptr: *const Querier,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    querier_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     selector_params: /*nullable*/ JString,
     callback: JObject,
@@ -69,6 +70,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
     encoding_id: jint,
     encoding_schema: /*nullable*/ JString,
 ) {
+    let querier_ptr = querier_ptr as *const Querier;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let querier = Arc::from_raw(querier_ptr);
     let _ = || -> ZResult<()> {
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -131,7 +134,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_getViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuerier_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    querier_ptr: *const Querier<'static>,
+    querier_ptr: jlong,
 ) {
+    let querier_ptr = querier_ptr as *const Querier<'static>;
     Arc::from_raw(querier_ptr);
 }

--- a/zenoh-jni/src/query.rs
+++ b/zenoh-jni/src/query.rs
@@ -60,8 +60,8 @@ use zenoh::{
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    query_ptr: *const Query,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    query_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     payload: JByteArray,
     encoding_id: jint,
@@ -71,6 +71,8 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
     attachment: /*nullable*/ JByteArray,
     qos_express: jboolean,
 ) {
+    let query_ptr = query_ptr as *const Query;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let _ = || -> ZResult<()> {
         let query = Arc::from_raw(query_ptr);
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -113,11 +115,12 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replySuccessViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyErrorViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    query_ptr: *const Query,
+    query_ptr: jlong,
     payload: JByteArray,
     encoding_id: jint,
     encoding_schema: /*nullable*/ JString,
 ) {
+    let query_ptr = query_ptr as *const Query;
     let _ = || -> ZResult<()> {
         let query = Arc::from_raw(query_ptr);
         let encoding = decode_encoding(&mut env, encoding_id, &encoding_schema)?;
@@ -157,14 +160,16 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyErrorViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyDeleteViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    query_ptr: *const Query,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    query_ptr: jlong,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     timestamp_enabled: jboolean,
     timestamp_ntp_64: jlong,
     attachment: /*nullable*/ JByteArray,
     qos_express: jboolean,
 ) {
+    let query_ptr = query_ptr as *const Query;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let _ = || -> ZResult<()> {
         let query = Arc::from_raw(query_ptr);
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -200,7 +205,8 @@ pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_replyDeleteViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQuery_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    query_ptr: *const Query,
+    query_ptr: jlong,
 ) {
+    let query_ptr = query_ptr as *const Query;
     Arc::from_raw(query_ptr);
 }

--- a/zenoh-jni/src/queryable.rs
+++ b/zenoh-jni/src/queryable.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{objects::JClass, JNIEnv};
@@ -35,7 +36,8 @@ use zenoh::query::Queryable;
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIQueryable_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    queryable_ptr: *const Queryable<()>,
+    queryable_ptr: jlong,
 ) {
+    let queryable_ptr = queryable_ptr as *const Queryable<()>;
     Arc::from_raw(queryable_ptr);
 }

--- a/zenoh-jni/src/scouting.rs
+++ b/zenoh-jni/src/scouting.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::{ptr::null, sync::Arc};
 
 use jni::{
@@ -43,8 +44,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIScout_00024Companion_scoutViaJNI(
     whatAmI: jint,
     callback: JObject,
     on_close: JObject,
-    config_ptr: /*nullable=*/ *const Config,
+    config_ptr: jlong,
 ) -> *const Scout<()> {
+    let config_ptr = config_ptr as *const Config;
     || -> ZResult<*const Scout<()>> {
         let callback_global_ref = get_callback_global_ref(&mut env, callback)?;
         let java_vm = Arc::new(get_java_vm(&mut env)?);
@@ -107,7 +109,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNIScout_00024Companion_scoutViaJNI(
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNIScout_00024Companion_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    scout_ptr: *const Scout<()>,
+    scout_ptr: jlong,
 ) {
+    let scout_ptr = scout_ptr as *const Scout<()>;
     Arc::from_raw(scout_ptr);
 }

--- a/zenoh-jni/src/session.rs
+++ b/zenoh-jni/src/session.rs
@@ -63,8 +63,9 @@ use crate::{
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_openSessionViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    config_ptr: *const Config,
+    config_ptr: jlong,
 ) -> *const Session {
+    let config_ptr = config_ptr as *const Config;
     let session = open_session(config_ptr);
     match session {
         Ok(session) => Arc::into_raw(Arc::new(session)),
@@ -194,8 +195,9 @@ fn open_session_with_yaml_config(env: &mut JNIEnv, yaml_config: JString) -> ZRes
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_closeSessionViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
+    session_ptr: jlong,
 ) {
+    let session_ptr = session_ptr as *const Session;
     Arc::from_raw(session_ptr);
 }
 
@@ -240,9 +242,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_closeSessionViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedSubscriberViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     // HistoryConfig
     history_config_enabled: jboolean,
     history_detect_late_publishers: jboolean,
@@ -258,6 +260,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedSubscriberV
     callback: JObject,
     on_close: JObject,
 ) -> *const AdvancedSubscriber<()> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let subscriber_ptr = || -> ZResult<*const AdvancedSubscriber<()>> {
         let mut builder = prepare_subscriber_builder(
@@ -365,9 +369,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedSubscriberV
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedPublisherViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     congestion_control: jint,
     priority: jint,
     is_express: jboolean,
@@ -386,6 +390,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedPublisherVi
 
     publisher_detection: jboolean,
 ) -> *const AdvancedPublisher<'static> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = OwnedObject::from_raw(session_ptr);
     let publisher_ptr = || -> ZResult<*const AdvancedPublisher<'static>> {
         let mut builder = prepare_publisher_builder(
@@ -491,14 +497,16 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareAdvancedPublisherVi
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declarePublisherViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     congestion_control: jint,
     priority: jint,
     is_express: jboolean,
     reliability: jint,
 ) -> *const Publisher<'static> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let publisher_ptr = || -> ZResult<*const Publisher<'static>> {
         prepare_publisher_builder(
@@ -578,9 +586,9 @@ unsafe fn prepare_publisher_builder<'a, 'b>(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     payload: JByteArray,
     encoding_id: jint,
     encoding_schema: JString,
@@ -590,6 +598,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
     attachment: JByteArray,
     reliability: jint,
 ) {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let _ = || -> ZResult<()> {
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -650,15 +660,17 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_putViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_deleteViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     congestion_control: jint,
     priority: jint,
     is_express: jboolean,
     attachment: JByteArray,
     reliability: jint,
 ) {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let _ = || -> ZResult<()> {
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -717,12 +729,14 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_deleteViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     callback: JObject,
     on_close: JObject,
 ) -> *const Subscriber<()> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let subscriber_ptr = || -> ZResult<*const Subscriber<()>> {
         prepare_subscriber_builder(
@@ -788,9 +802,9 @@ unsafe fn prepare_subscriber_builder<'a, 'b>(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQuerierViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     target: jint,
     consolidation: jint,
     congestion_control: jint,
@@ -799,6 +813,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQuerierViaJNI(
     timeout_ms: jlong,
     accept_replies: jint,
 ) -> *const Querier<'static> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     || -> ZResult<*const Querier<'static>> {
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -865,13 +881,15 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQuerierViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareQueryableViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     callback: JObject,
     on_close: JObject,
     complete: jboolean,
 ) -> *const Queryable<()> {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let query_ptr = || -> ZResult<*const Queryable<()>> {
         let java_vm = Arc::new(get_java_vm(&mut env)?);
@@ -1019,9 +1037,10 @@ fn on_query(mut env: JNIEnv, query: Query, callback_global_ref: &GlobalRef) -> Z
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareKeyExprViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     key_expr_str: JString,
 ) -> *const KeyExpr<'static> {
+    let session_ptr = session_ptr as *const Session;
     let session: Arc<Session> = Arc::from_raw(session_ptr);
     let key_expr_ptr = || -> ZResult<*const KeyExpr<'static>> {
         let key_expr_str = decode_string(&mut env, &key_expr_str)?;
@@ -1070,9 +1089,11 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareKeyExprViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_undeclareKeyExprViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
-    key_expr_ptr: *const KeyExpr<'static>,
+    session_ptr: jlong,
+    key_expr_ptr: jlong,
 ) {
+    let session_ptr = session_ptr as *const Session;
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
     let session = Arc::from_raw(session_ptr);
     let key_expr = Arc::from_raw(key_expr_ptr);
     let key_expr_clone = key_expr.deref().clone();
@@ -1128,10 +1149,10 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_undeclareKeyExprViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,
+    key_expr_ptr: jlong,
     key_expr_str: JString,
     selector_params: /*nullable*/ JString,
-    session_ptr: *const Session,
+    session_ptr: jlong,
     callback: JObject,
     on_close: JObject,
     timeout_ms: jlong,
@@ -1146,6 +1167,8 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getViaJNI(
     is_express: jboolean,
     accept_replies: jint,
 ) {
+    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let _ = || -> ZResult<()> {
         let key_expr = process_kotlin_key_expr(&mut env, &key_expr_str, key_expr_ptr)?;
@@ -1374,8 +1397,9 @@ pub(crate) fn on_reply_error(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getPeersZidViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
+    session_ptr: jlong,
 ) -> jobject {
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let ids = {
         let peers_zid = session.info().peers_zid().wait();
@@ -1397,8 +1421,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getPeersZidViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getRoutersZidViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
+    session_ptr: jlong,
 ) -> jobject {
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let ids = {
         let peers_zid = session.info().routers_zid().wait();
@@ -1419,8 +1444,9 @@ pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getRoutersZidViaJNI(
 pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_getZidViaJNI(
     mut env: JNIEnv,
     _class: JClass,
-    session_ptr: *const Session,
+    session_ptr: jlong,
 ) -> jbyteArray {
+    let session_ptr = session_ptr as *const Session;
     let session = Arc::from_raw(session_ptr);
     let ids = {
         let zid = session.info().zid().wait();

--- a/zenoh-jni/src/subscriber.rs
+++ b/zenoh-jni/src/subscriber.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use jni::sys::jlong;
 use std::sync::Arc;
 
 use jni::{objects::JClass, JNIEnv};
@@ -35,7 +36,8 @@ use zenoh::pubsub::Subscriber;
 pub(crate) unsafe extern "C" fn Java_io_zenoh_jni_JNISubscriber_freePtrViaJNI(
     _env: JNIEnv,
     _: JClass,
-    subscriber_ptr: *const Subscriber<()>,
+    subscriber_ptr: jlong,
 ) {
+    let subscriber_ptr = subscriber_ptr as *const Subscriber<()>;
     Arc::from_raw(subscriber_ptr);
 }


### PR DESCRIPTION
## Problem

Every `zenoh-jni` `extern "C"` function that receives a native pointer typed as `*const T` (e.g. `key_expr_ptr: *const KeyExpr<'static>`, `session_ptr: *const Session`) is ABI-incorrect on **32-bit** Android ABIs (`armeabi-v7a`, `x86`). The Kotlin layer always passes these pointers as `Long` (`jlong`, 8 bytes), but `*const T` is **4 bytes** on a 32-bit target. When such a pointer argument is followed by any further argument, the callee under-reads it by 4 bytes and **every subsequent argument shifts by one slot**.

The most visible victim is the key-expression string, declared right after `key_expr_ptr`: on 32-bit it ends up reading the high half of the (usually null) pointer → a **null `jstring`** → `decode_string` → `env.get_string` → `GetObjectClass(null)`:

```
Unable to get key expression string value:
  'Error while retrieving JString: Null pointer in get_object_class'
```

So `declareSubscriber`, `declarePublisher`, `declareQueryable`, `put`/`get`/`delete`, key-expr `intersects`/`includes`/`relationTo`, and the `zenoh-ext` advanced pub/sub all fail on 32-bit ABIs. 64-bit ABIs (`arm64-v8a`, `x86_64`) are unaffected because there a pointer is also 8 bytes, so the declared layout coincidentally matches `jlong`. `KeyExpr.tryFrom` (`intoKeyExpr`) works on 32-bit too, because its JNI function (`tryFromViaJNI(env, class, JString)`) has no pointer argument before the `JString`.

## Root cause (armeabi-v7a / AAPCS walk-through)

`Session.declareSubscriber`:

```kotlin
internal class JNIKeyExpr(internal val ptr: Long)            // pointer is a Long
private external fun declareSubscriberViaJNI(
    keyExprPtr: Long,        // 8-byte jlong (0 for an undeclared key expr)
    keyExprStr: String,
    sessionPtr: Long,
    callback: JNISubscriberCallback,
    onClose: JNIOnCloseCallback,
): Long
```

```rust
pub unsafe extern "C" fn Java_io_zenoh_jni_JNISession_declareSubscriberViaJNI(
    mut env: JNIEnv,
    _class: JClass,
    key_expr_ptr: /*nullable*/ *const KeyExpr<'static>,   // 4 bytes on armv7!
    key_expr_str: JString,
    session_ptr: *const Session,                          // 4 bytes on armv7!
    callback: JObject,
    on_close: JObject,
) -> *const Subscriber<()>
```

An 8-byte `jlong` takes an even-aligned register pair, so:

| reg/slot | JVM passes (Kotlin `(Long, String, Long, …)`) | Rust reads (declared types) |
|---|---|---|
| r0 | `JNIEnv*` | `env` |
| r1 | `jclass` | `_class` |
| r2 | `keyExprPtr` low 32 | `key_expr_ptr` (`*const`, 4B) ✓ |
| r3 | `keyExprPtr` **high 32** | `key_expr_str` (`JString`, 4B) ✗ |
| stack | `keyExprStr` (jstring) | `session_ptr` … |

For an `intoKeyExpr` key expression `jniKeyExpr` is null, so Kotlin passes `keyExprPtr = 0L`. Rust then reads `key_expr_ptr = 0` (→ `is_null()`, takes the `decode_string` path) and `key_expr_str = 0` (the high half of the null pointer) → null `jstring` → `GetObjectClass(null)`.

## Fix

Type every pointer-passing JNI argument as `jlong` (matching the Kotlin `Long` on all targets) and rebind it to the pointer type at the top of the function:

```rust
    key_expr_ptr: jlong,
    key_expr_str: JString,
    session_ptr: jlong,
    ...
) -> *const Subscriber<()> {
    let key_expr_ptr = key_expr_ptr as *const KeyExpr<'static>;
    let session_ptr  = session_ptr  as *const Session;
    // ... unchanged ...
```

`jlong as *const T` truncates to pointer width, so it is correct on both 32- and 64-bit. The Kotlin side already passes these handles as `Long`; the Rust signatures simply hadn't adopted the matching `jlong` typing plus an explicit cast. Internal (non-`extern "C"`) helpers such as `process_kotlin_key_expr(.., key_expr_ptr: *const KeyExpr)` keep their pointer type and receive the rebound value: unchanged.

This PR changes **74 pointer arguments across 55 `extern "C"` functions** in `config.rs`, `key_expr.rs`, `session.rs`, `publisher.rs`, `querier.rs`, `query.rs`, `queryable.rs`, `subscriber.rs`, `scouting.rs`, `liveliness.rs`, and the `ext/` advanced pub/sub.

### Scope note: return values

Pointer **return** types (`-> *const Session`, etc.) are technically also narrow on 32-bit: the returned `Long` has undefined high 32 bits. In practice this is benign, the low half is the valid pointer and is re-truncated when the handle is passed back in, and the error path throws before the value is observed, so this PR leaves the return types as-is to keep the change focused on the argument bug that actually breaks pub/sub. Typing the returns as `jlong` too (returning `ptr as jlong`) would make the boundary fully explicit and can follow as a separate change if preferred.

## Testing

- `cargo fmt --check` and `cargo clippy --all-features -- -D warnings` pass.
- Cross-built `libzenoh_jni.so` for `armv7-linux-androideabi` (NDK r26) and ran it on a **32-bit-only Samsung Galaxy Watch 6 Classic (SM-R960, Wear OS 6)**. Before: `Zenoh.open` + `intoKeyExpr` succeed, `declareSubscriber` fails with the `get_object_class` error above. After: a full peer session opens, `declareSubscriber` and `put` succeed, and a live pub/sub runs end-to-end.
- `arm64-v8a` / `x86_64` behaviour is I think unchanged (the cast should be a no-op there).