### PR TITLE
Parameters becomes a thin facade over the shared string-backed implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: 67f2ff826fb7bb3b6a9787363fecf91c4ac4cef1
+          ref: 6a19a646e722eb9be844c0d3f5eda9002b2e95be
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat
-          ref: 108ebae6e1e900a682013aabbe6a1c14f52d940f
+          ref: 1ece3df5e64db63f980a43e8ae661bdd5ed760c2
           path: zenoh-flat
 
       - name: Use prebindgen from GitHub main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: 6a19a646e722eb9be844c0d3f5eda9002b2e95be
+          ref: 757cc6ad7e346f428ffc5e3252ba01ff4d19ba9b
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat
-          ref: 925ea5b2ffd534b3d0632be7d002e6a022262dce
+          ref: 108ebae6e1e900a682013aabbe6a1c14f52d940f
           path: zenoh-flat
 
       - name: Use prebindgen from GitHub main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: dbb1f8c6509e333f49d1c03ecb84dcf07b7af7b8
+          ref: 67f2ff826fb7bb3b6a9787363fecf91c4ac4cef1
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat
-          ref: 6d22091d75912be1c14330b0f78fa1d4bf258ea3
+          ref: 925ea5b2ffd534b3d0632be7d002e6a022262dce
           path: zenoh-flat
 
       - name: Use prebindgen from GitHub main

--- a/ZENOH_FLAT_TRANSITION.md
+++ b/ZENOH_FLAT_TRANSITION.md
@@ -47,7 +47,8 @@ the sink reports those without throwing.
 
 | PR | Scope | Status |
 | --- | --- | --- |
-| [#668](https://github.com/eclipse-zenoh/zenoh-kotlin/pull/668) | Port zenoh-kotlin to zenoh-flat-jni generated bindings | open |
+| [#668](https://github.com/eclipse-zenoh/zenoh-kotlin/pull/668) | Port zenoh-kotlin to zenoh-flat-jni generated bindings | merged |
+| shared-parameters | `Parameters` becomes a thin facade over the shared string-backed implementation in zenoh-flat-jni (Rust `parameters.rs` semantics: no percent-decoding, infallible parse, first-match-wins get). Pairs with [zenoh-flat#4](https://github.com/ZettaScaleLabs/zenoh-flat/pull/4), [zenoh-flat-jni#9](https://github.com/ZettaScaleLabs/zenoh-flat-jni/pull/9) | open |
 
 Planned follow-ups on this branch:
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Parameters.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Parameters.kt
@@ -14,114 +14,73 @@
 
 package io.zenoh.query
 
-import java.net.URLDecoder
+import io.zenoh.jni.query.Parameters as JniParameters
 
 /**
  * Parameters of the [Selector].
  *
- * When in string form, the `parameters` should be encoded like the query section of a URL:
- *  - parameters are separated by `;`,
+ * A thin facade over the shared string-backed implementation
+ * ([io.zenoh.jni.query.Parameters]), which mirrors Rust's
+ * `zenoh::query::Parameters` exactly. The string form follows the
+ * `a=b;c=d|e;f=g` format:
+ *  - parameters are separated by `;` (empty chunks are skipped),
  *  - the parameter name and value are separated by the first `=`,
  *  - in the absence of `=`, the parameter value is considered to be the empty string,
- *  - both name and value should use percent-encoding to escape characters,
- *  - defining a value for the same parameter name twice is considered undefined behavior and an
- *    error result is returned.
+ *  - the value is taken verbatim (no percent-decoding),
+ *  - a duplicated parameter name is allowed: [get] returns the FIRST
+ *    occurrence, and the duplicates survive round-tripping until an
+ *    [insert]/[remove] normalizes the string.
  *
  * @see Selector
  */
-data class Parameters internal constructor(private val params: MutableMap<String, String>) : IntoParameters {
+class Parameters internal constructor(internal val inner: JniParameters) : IntoParameters {
 
     companion object {
-
-        private const val LIST_SEPARATOR = ";"
-        private const val FIELD_SEPARATOR = "="
-        private const val VALUE_SEPARATOR = "|"
 
         /**
          * Creates an empty Parameters.
          */
-        fun empty() = Parameters(mutableMapOf())
+        fun empty() = Parameters(JniParameters.empty())
 
         /**
          * Creates a [Parameters] instance from the provided map.
          */
-        fun from(params: Map<String, String>): Parameters = Parameters(params.toMutableMap())
+        fun from(params: Map<String, String>): Parameters = Parameters(JniParameters.fromMap(params))
 
         /**
-         * Attempts to create a [Parameters] from a string.
+         * Creates a [Parameters] from a string in the `a=b;c=d|e;f=g` format.
          *
-         * When in string form, the `parameters` should be encoded like the query section of a URL:
-         *  - parameters are separated by `;`,
-         *  - the parameter name and value are separated by the first `=`,
-         *  - in the absence of `=`, the parameter value is considered to be the empty string,
-         *  - both name and value should use percent-encoding to escape characters,
-         *  - defining a value for the same parameter name twice is considered undefined behavior and an
-         *    error result is returned.
+         * Construction is infallible — any string is accepted, exactly as in
+         * the Rust layer (the result is always [Result.success]; the [Result]
+         * signature is kept for source compatibility).
          */
-        fun from(params: String): Result<Parameters> = runCatching {
-            if (params.isBlank()) {
-                return@runCatching Parameters(mutableMapOf())
-            }
-            params.split(LIST_SEPARATOR).fold(mutableMapOf<String, String>()) { parametersMap, parameter ->
-                val (key, value) = parameter.split(FIELD_SEPARATOR).let { it[0] to it.getOrNull(1) }
-                require(!parametersMap.containsKey(key)) { "Duplicated parameter `$key` detected." }
-                parametersMap[key] = value?.let { URLDecoder.decode(it, Charsets.UTF_8.name()) } ?: ""
-                parametersMap
-            }.let { Parameters(it) }
-        }
-
-        /**
-         * Parses [params] LENIENTLY, accepting any input — used on the
-         * RECEIVE path, where the string arrives from the network. In the
-         * Rust layer a selector's parameters are an unvalidated string view
-         * (any string is valid), so a remote client is free to send input
-         * the strict [from] rejects; the binding must never fault on it:
-         *  - on a duplicated parameter name, the FIRST occurrence wins
-         *    (mirroring the Rust `Parameters::get` semantics),
-         *  - the name and value are separated by the first `=` (the value
-         *    may contain further `=`),
-         *  - a value that fails percent-decoding is kept verbatim.
-         */
-        internal fun fromLenient(params: String): Parameters {
-            if (params.isBlank()) {
-                return Parameters(mutableMapOf())
-            }
-            return params.split(LIST_SEPARATOR).fold(mutableMapOf<String, String>()) { parametersMap, parameter ->
-                val (key, value) = parameter.split(FIELD_SEPARATOR, limit = 2).let { it[0] to it.getOrNull(1) }
-                if (!parametersMap.containsKey(key)) {
-                    parametersMap[key] = value?.let { v ->
-                        runCatching { URLDecoder.decode(v, Charsets.UTF_8.name()) }.getOrDefault(v)
-                    } ?: ""
-                }
-                parametersMap
-            }.let { Parameters(it) }
-        }
+        fun from(params: String): Result<Parameters> =
+            Result.success(Parameters(JniParameters.fromString(params)))
     }
 
-    override fun toString(): String =
-        params.entries.joinToString(LIST_SEPARATOR) { "${it.key}$FIELD_SEPARATOR${it.value}" }
+    override fun toString(): String = inner.toString()
 
     override fun into(): Parameters = this
 
     /**
      * Returns empty if no parameters were provided.
      */
-    fun isEmpty(): Boolean = params.isEmpty()
+    fun isEmpty(): Boolean = inner.isEmpty()
 
     /**
      * Returns true if the [key] is contained.
      */
-    fun containsKey(key: String): Boolean = params.containsKey(key)
+    fun containsKey(key: String): Boolean = inner.containsKey(key)
 
     /**
-     * Returns the value of the [key] if present.
+     * Returns the value of the [key] if present (the first occurrence wins).
      */
-    fun get(key: String): String? = params[key]
+    fun get(key: String): String? = inner.get(key)
 
     /**
      * Returns the value of the [key] if present, or if not, the [default] value provided.
      */
-    fun getOrDefault(key: String, default: String): String = params.getOrDefault(key, default)
+    fun getOrDefault(key: String, default: String): String = inner.getOrDefault(key, default)
 
     /**
      * Returns the values of the [key] if present.
@@ -132,25 +91,25 @@ data class Parameters internal constructor(private val params: MutableMap<String
      * assertEquals(listOf("1", "2", "3"), parameters.values("c"))
      * ```
      */
-    fun values(key: String): List<String>? = params[key]?.split(VALUE_SEPARATOR)
+    fun values(key: String): List<String>? = if (inner.containsKey(key)) inner.values(key) else null
 
     /**
      * Inserts the key-value pair into the parameters, returning the old value
      * in case of it being already present.
      */
-    fun insert(key: String, value: String): String? = params.put(key, value)
+    fun insert(key: String, value: String): String? = inner.insert(key, value)
 
     /**
      * Removes the [key] parameter, returning its value.
      */
-    fun remove(key: String): String? = params.remove(key)
+    fun remove(key: String): String? = inner.remove(key)
 
     /**
      * Extends the parameters with the [parameters] provided, overwriting
      * any conflicting params.
      */
     fun extend(parameters: IntoParameters) {
-        params.putAll(parameters.into().params)
+        inner.extend(parameters.into().inner)
     }
 
     /**
@@ -158,13 +117,18 @@ data class Parameters internal constructor(private val params: MutableMap<String
      * any conflicting params.
      */
     fun extend(parameters: Map<String, String>) {
-        params.putAll(parameters)
+        inner.extend(parameters)
     }
 
     /**
-     * Returns a map with the key value pairs of the parameters.
+     * Returns a map with the key value pairs of the parameters. For a
+     * duplicated key the last occurrence wins (unlike [get]).
      */
-    fun toMap(): Map<String, String> = params
+    fun toMap(): Map<String, String> = inner.toMap()
+
+    override fun equals(other: Any?): Boolean = other is Parameters && inner == other.inner
+
+    override fun hashCode(): Int = inner.hashCode()
 }
 
 interface IntoParameters {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
@@ -256,10 +256,10 @@ class Query internal constructor(
         ): Query {
             val ke = KeyExpr(keStr)
             // The parameters string is ATTACKER-CONTROLLED (the Rust layer
-            // forwards any selector parameters untouched) — parse leniently,
-            // never throw.
+            // forwards any selector parameters untouched) — the shared
+            // string-backed Parameters accepts any input, never throwing.
             val selector = if (parameters.isEmpty()) Selector(ke)
-                else Selector(ke, Parameters.fromLenient(parameters))
+                else Selector(ke, Parameters.from(parameters).getOrThrow())
             return Query(
                 ke,
                 selector,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Selector.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Selector.kt
@@ -28,13 +28,12 @@ import io.zenoh.keyexpr.KeyExpr
  *
  * When in string form, selectors look a lot like a URI, with similar semantics:
  * - the `key_expr` before the first `?` must be a valid key expression.
- * - the `parameters` after the first `?` should be encoded like the query section of a URL:
+ * - the `parameters` after the first `?` follow the `a=b;c=d|e;f=g` format:
  *     - parameters are separated by `;`,
  *     - the parameter name and value are separated by the first `=`,
  *     - in the absence of `=`, the parameter value is considered to be the empty string,
- *     - both name and value should use percent-encoding to escape characters,
- *     - defining a value for the same parameter name twice is considered undefined behavior,
- *       with the encouraged behaviour being to reject operations when a duplicate parameter is detected.
+ *     - the value is taken verbatim (no percent-decoding is applied),
+ *     - a duplicated parameter name is allowed; lookups return the first occurrence.
  *
  * Zenoh intends to standardize the usage of a set of parameter names. To avoid conflicting with RPC parameters,
  * the Zenoh team has settled on reserving the set of parameter names that start with non-alphanumeric characters.
@@ -60,13 +59,12 @@ data class Selector(val keyExpr: KeyExpr, val parameters: Parameters? = null) : 
          *
          * When in string form, selectors look a lot like a URI, with similar semantics:
          * - the `key_expr` before the first `?` must be a valid key expression.
-         * - the `parameters` after the first `?` should be encoded like the query section of a URL:
+         * - the `parameters` after the first `?` follow the `a=b;c=d|e;f=g` format:
          *     - parameters are separated by `;`,
          *     - the parameter name and value are separated by the first `=`,
          *     - in the absence of `=`, the parameter value is considered to be the empty string,
-         *     - both name and value should use percent-encoding to escape characters,
-         *     - defining a value for the same parameter name twice is considered undefined behavior,
-         *       with the encouraged behaviour being to reject operations when a duplicate parameter is detected.
+         *     - the value is taken verbatim (no percent-decoding is applied),
+         *     - a duplicated parameter name is allowed; lookups return the first occurrence.
          *
          * @param selector The selector expression as a String.
          * @return a Result with the constructed Selector.

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ParametersTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ParametersTest.kt
@@ -26,26 +26,31 @@ class ParametersTest {
     }
 
     @Test
-    fun `lenient parsing accepts any remote input`() {
-        // The receive path must be total on attacker-controlled input, as the
-        // Rust layer is (a selector's parameters are an unvalidated string
-        // view there). The strict parser rejects all of these.
+    fun `parsing accepts any remote input with Rust semantics`() {
+        // Parsing is total on attacker-controlled input, exactly as the Rust
+        // layer (a selector's parameters are an unvalidated string view).
 
-        // Duplicated parameter name: the FIRST occurrence wins.
-        assertTrue(Parameters.from("a=1;a=2").isFailure)
-        assertEquals("1", Parameters.fromLenient("a=1;a=2").get("a"))
+        // Duplicated parameter name: accepted, the FIRST occurrence wins on get.
+        assertEquals("1", Parameters.from("a=1;a=2").getOrThrow().get("a"))
 
-        // Invalid percent-encoding: the value is kept verbatim.
-        assertTrue(Parameters.from("k=%zz").isFailure)
-        assertEquals("%zz", Parameters.fromLenient("k=%zz").get("k"))
+        // No percent-decoding: the value is kept verbatim.
+        assertEquals("%zz", Parameters.from("k=%zz").getOrThrow().get("k"))
+        assertEquals("%20", Parameters.from("k=%20").getOrThrow().get("k"))
 
         // Value containing '=': split on the FIRST '=' only.
-        assertEquals("b=c", Parameters.fromLenient("a=b=c").get("a"))
+        assertEquals("b=c", Parameters.from("a=b=c").getOrThrow().get("a"))
 
         // Flag without a value, empty chunks, blank input: all accepted.
-        assertEquals("", Parameters.fromLenient("flag").get("flag"))
-        assertEquals("1", Parameters.fromLenient(";;a=1;;").get("a"))
-        assertTrue(Parameters.fromLenient("").isEmpty())
+        assertEquals("", Parameters.from("flag").getOrThrow().get("flag"))
+        assertEquals("1", Parameters.from(";;a=1;;").getOrThrow().get("a"))
+        assertTrue(Parameters.from("").getOrThrow().isEmpty())
+
+        // The string round-trips verbatim (duplicates preserved) until an
+        // insert/remove normalizes it.
+        val p = Parameters.from("a=1;a=2;flag").getOrThrow()
+        assertEquals("a=1;a=2;flag", p.toString())
+        p.insert("a", "3")
+        assertEquals("flag;a=3", p.toString())
     }
 
     @Test


### PR DESCRIPTION
`io.zenoh.query.Parameters` now delegates every operation to the shared `io.zenoh.jni.query.Parameters` (ZettaScaleLabs/zenoh-flat-jni#9) — a pure-Kotlin, string-backed mirror of Rust's `zenoh-protocol/core/parameters.rs`. This ends the duplicated (and Rust-divergent) per-SDK parsers introduced by the malformed-selector-parameters hardening: construction is now infallible on any remote (attacker-controlled) input, with **zero JNI crossings** on the production path.

## Behavior changes (all aligning with Rust)

1. Values are **no longer percent-decoded** — the URL-encoding claim in the old docs was a zenoh-jni legacy; Rust takes values verbatim. Docs updated (`Parameters`, `Selector`).
2. `from(String)` never fails: the `Result` signature is kept for source compatibility and is always success. Duplicated keys are accepted — `get` returns the FIRST occurrence (`toMap` keeps the last, as Rust's `HashMap` conversion).
3. `toString()` round-trips the stored string verbatim; `insert`/`remove` normalize (drop empty keys, omit `=` for empty values).
4. Equality is string equality (`"a=1;b=2" != "b=2;a=1"`), as Rust.

`fromLenient` is deleted — superseded, the shared parse is inherently total.

## Pairing

Merge order: ZettaScaleLabs/zenoh-flat#4 (the parameters-processing API — regular any-language zenoh-flat API, wrapped directly by ZettaScaleLabs/zenoh-flat-c#1) → ZettaScaleLabs/zenoh-flat-jni#9 (shared pure-Kotlin implementation + declarations) → this (CI pins bumped to both). The JVM runs the semantics in pure Kotlin because crossing JNI per string operation is expensive — a JNI peculiarity, not a zenoh-flat design choice; the randomized correspondence test against the native implementation lives in the zenoh-java companion PR.

## Testing

`gradle jvmTest`: 117 tests, 0 failed, 12 skipped (pre-existing @Ignores). Includes the rewritten `ParametersTest` Rust-semantics section and the `queryable_receivesMalformedParametersQuery` e2e (raw-bindings `a=1;a=2;bad=%zz` query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
