### PR TITLE
Migrate to the split error-handler API (zenoh-flat-jni #45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: 757cc6ad7e346f428ffc5e3252ba01ff4d19ba9b
+          ref: 249fe9e34ac5d05bc442355fd216a324114e2621
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -160,7 +160,9 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromFile(path: Path): Result<Config> =
-            zCall({ JniConfig(0L) }) { JniConfig.newFromFile(path.toString(), it) }.map { Config(it) }
+            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+                JniConfig.newFromFile(path.toString(), onBindingError, onError)
+            }.map { Config(it) }
 
         /**
          * Loads the configuration from json-formatted string.
@@ -195,7 +197,9 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromJson(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { JniConfig.newFromJson(config, it) }.map { Config(it) }
+            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+                JniConfig.newFromJson(config, onBindingError, onError)
+            }.map { Config(it) }
 
         /**
          * Loads the configuration from json5-formatted string.
@@ -230,7 +234,9 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromJson5(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { JniConfig.newFromJson5(config, it) }.map { Config(it) }
+            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+                JniConfig.newFromJson5(config, onBindingError, onError)
+            }.map { Config(it) }
 
         /**
          * Loads the configuration from yaml-formatted string.
@@ -261,7 +267,9 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromYaml(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { JniConfig.newFromYaml(config, it) }.map { Config(it) }
+            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+                JniConfig.newFromYaml(config, onBindingError, onError)
+            }.map { Config(it) }
 
         /**
          * Loads the configuration from the [jsonElement] specified.
@@ -287,7 +295,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
      * Returns the json value associated to the [key].
      */
     fun getJson(key: String): Result<String> {
-        return zCall({ "" }) { jniConfig.getJson(key, it) }
+        return zCall({ "" }) { onBindingError, onError -> jniConfig.getJson(key, onBindingError, onError) }
     }
 
     /**
@@ -311,6 +319,6 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
      * @return A result with the status of the operation.
      */
     fun insertJson5(key: String, value: String): Result<Unit> {
-        return zCallUnit { jniConfig.insertJson5(key, value, it) }
+        return zCallUnit { onBindingError, onError -> jniConfig.insertJson5(key, value, onBindingError, onError) }
     }
 }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -668,7 +668,9 @@ class Session private constructor(private val config: Config) : AutoCloseable {
      */
     fun declareKeyExpr(keyExpr: String): Result<KeyExpr> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniKeyExpr(0L) }) { session.declareKeyexpr(keyExpr, it) }
+        return zCall({ JniKeyExpr(0L) }) { onBindingError, onError ->
+            session.declareKeyexpr(keyExpr, onBindingError, onError)
+        }
             .map { KeyExpr(keyExpr, it) }
             .onSuccess { strongDeclarations.add(it) }
     }
@@ -686,7 +688,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         val session = jniSession ?: return Result.failure(sessionClosedException)
         val handle = keyExpr.jniKeyExpr
             ?: return Result.failure(ZError("Key expression is not declared through a session."))
-        return zCallUnit { session.undeclareKeyexpr(handle, it) }
+        return zCallUnit { onBindingError, onError -> session.undeclareKeyexpr(handle, onBindingError, onError) }
             .also {
                 // The generated wrapper consumes the handle even when the
                 // native undeclare fails (the Rust side takes it by value);
@@ -1102,12 +1104,12 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         reliability: Reliability
     ): Result<Publisher> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniPublisher(0L) }) { onError ->
+        return zCall({ JniPublisher(0L) }) { onBindingError, onError ->
             session.declarePublisher(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 encoding.jniSel, encoding.jniId, encoding.jniSchema, encoding.jniHandle,
                 qos.congestionControl.jni, qos.priority.jni, qos.express, reliability.jni,
-                onError
+                onBindingError, onError
             )
         }.map { Publisher(keyExpr, qos, encoding, it) }
             .onSuccess { weakDeclarations.add(WeakReference(it)) }
@@ -1120,12 +1122,12 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         receiver: R
     ): Result<Subscriber<R>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniSubscriber(0L) }) { onError ->
+        return zCall({ JniSubscriber(0L) }) { onBindingError, onError ->
             session.declareSubscriber(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 sampleCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { Subscriber(keyExpr, receiver, it) }
             .onSuccess { strongDeclarations.add(it) }
@@ -1139,13 +1141,13 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         complete: Boolean
     ): Result<Queryable<R>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniQueryable(0L) }) { onError ->
+        return zCall({ JniQueryable(0L) }) { onBindingError, onError ->
             session.declareQueryable(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 complete,
                 queryCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { Queryable(keyExpr, receiver, it) }
             .onSuccess { strongDeclarations.add(it) }
@@ -1160,13 +1162,13 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         acceptReplies: ReplyKeyExpr
     ): Result<Querier> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniQuerier(0L) }) { onError ->
+        return zCall({ JniQuerier(0L) }) { onBindingError, onError ->
             session.declareQuerier(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 target.jni, consolidation.jni,
                 qos.congestionControl.jni, qos.priority.jni, qos.express,
                 timeout.toMillis(), acceptReplies.jni,
-                onError
+                onBindingError, onError
             )
         }.map { Querier(keyExpr, qos, it) }
             .onSuccess { weakDeclarations.add(WeakReference(it)) }
@@ -1187,7 +1189,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         acceptReplies: ReplyKeyExpr
     ): Result<R> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             session.get(
                 selector.keyExpr.jniSel, selector.keyExpr.jniStr, selector.keyExpr.jniHandle,
                 selector.parameters?.toString(),
@@ -1199,14 +1201,14 @@ class Session private constructor(private val config: Config) : AutoCloseable {
                 attachment?.into()?.bytes,
                 replyCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { receiver }
     }
 
     private fun resolvePut(keyExpr: KeyExpr, put: Put): Result<Unit> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             session.put(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.jniHandle,
                 put.payload.bytes,
@@ -1214,20 +1216,20 @@ class Session private constructor(private val config: Config) : AutoCloseable {
                 put.qos.congestionControl.jni, put.qos.priority.jni, put.qos.express,
                 put.attachment?.bytes,
                 put.reliability.jni,
-                onError
+                onBindingError, onError
             )
         }
     }
 
     private fun resolveDelete(keyExpr: KeyExpr, delete: Delete): Result<Unit> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             session.delete(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.jniHandle,
                 delete.qos.congestionControl.jni, delete.qos.priority.jni, delete.qos.express,
                 delete.attachment?.bytes,
                 delete.reliability.jni,
-                onError
+                onBindingError, onError
             )
         }
     }
@@ -1255,7 +1257,9 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         // `open` consumes its config; clone so the user's [Config] stays reusable.
         val cloned = zCall0({ JniConfig(0L) }) { config.jniConfig.newClone(it) }
             .getOrElse { return Result.failure(it) }
-        return zCall({ JniSession(0L) }) { JniSession.open(cloned, it) }
+        return zCall({ JniSession(0L) }) { onBindingError, onError ->
+            JniSession.open(cloned, onBindingError, onError)
+        }
             .map {
                 jniSession = it
                 this@Session

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
@@ -100,7 +100,7 @@ object Zenoh {
         whatAmI: Set<WhatAmI>,
         config: Config?
     ): Result<Scout<R>> {
-        return zCall({ JniScout(0L) }) { onError ->
+        return zCall({ JniScout(0L) }) { onBindingError, onError ->
             // Argument preparation stays inside the captured block: an empty
             // [whatAmI] makes `reduce` throw, which must surface as
             // Result.failure (the pre-flat API contract).
@@ -110,7 +110,7 @@ object Zenoh {
                 config?.jniConfig,
                 helloCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { Scout(receiver, it) }
     }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/exceptions/ResultHandlers.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/exceptions/ResultHandlers.kt
@@ -24,12 +24,17 @@ import io.zenoh.jni.JniErrorHandler
  * Two distinct failure channels are folded into one [Result]:
  *
  * 1. **Native errors** — a generated wrapper never throws from native code;
- *    on failure it *returns* the value produced by its trailing `onError`
- *    handler (a generated typed `fun interface`). The helpers supply a
- *    handler that records the error into a local and, where the wrapper's
- *    return type demands a value, produces a throw-away *sentinel* (a
- *    born-closed handle such as `Session(0L)`, an empty list, …). No
- *    exception is ever in flight for a native error.
+ *    on failure it *returns* the value produced by an error handler (a
+ *    generated typed `fun interface`). A fallible wrapper has TWO handler
+ *    channels (prebindgen #45): `onBindingError` (a [JniErrorHandler], any
+ *    binding-layer failure — UTF-8 decode, closed handle, …) and `onError`
+ *    (the typed domain [ErrorHandler], the decomposed zenoh error message).
+ *    The [zCall]/[zCallUnit] helpers supply BOTH — each records the error
+ *    into one local and, where the wrapper's return type demands a value,
+ *    produces a throw-away *sentinel* (a born-closed handle such as
+ *    `Session(0L)`, an empty list, …). No exception is ever in flight for a
+ *    native error. Binding-only-fallible wrappers ([zCall0]/[zCallUnit0]) take
+ *    just the single [JniErrorHandler].
  * 2. **JVM-side exceptions** — argument preparation (collection ops, …),
  *    user-supplied conversions (`IntoZBytes.into()`), and class
  *    initialization (native-library loading) can throw before or around the
@@ -38,20 +43,23 @@ import io.zenoh.jni.JniErrorHandler
  *    pre-flat API. The `runCatching` never observes a native error — channel
  *    1 reports those without throwing.
  *
- * `je` is the binding-layer error (UTF-8 decode, closed handle, …); `message`
- * is the library (zenoh) error message. Exactly one is set.
- *
  * For the few non-[Result] contexts (where the public API today already lets
  * an unchecked [ZError] propagate), [throwZError]/[throwZError0] throw from
  * the handler instead — documented safe, as the handler runs after the native
  * call has returned.
  */
 
-/** Fallible flat call returning `Unit` — no sentinel needed. */
-internal inline fun zCallUnit(crossinline block: (ErrorHandler<Unit>) -> Unit): Result<Unit> {
+/** Fallible flat call returning `Unit` — no sentinel needed. The wrapper takes
+ * both channels (`onBindingError`, `onError`); each records into [err]. */
+internal inline fun zCallUnit(
+    crossinline block: (JniErrorHandler<Unit>, ErrorHandler<Unit>) -> Unit
+): Result<Unit> {
     var err: ZError? = null
     val outcome = runCatching {
-        block(ErrorHandler { je, message -> err = ZError(je ?: message) })
+        block(
+            JniErrorHandler { je -> err = ZError(je ?: "native binding error") },
+            ErrorHandler { message -> err = ZError(message) },
+        )
     }
     err?.let { return Result.failure(it) }
     return outcome
@@ -69,19 +77,25 @@ internal inline fun zCallUnit0(crossinline block: (JniErrorHandler<Unit>) -> Uni
 
 /**
  * Fallible flat call returning `T`; [sentinel] runs only on the error path to
- * satisfy the wrapper's return type (its value is discarded).
+ * satisfy the wrapper's return type (its value is discarded). The wrapper takes
+ * both channels (`onBindingError`, `onError`); each records into [err] and
+ * produces the sentinel.
  */
 internal inline fun <T> zCall(
     crossinline sentinel: () -> T,
-    crossinline block: (ErrorHandler<T>) -> T
+    crossinline block: (JniErrorHandler<T>, ErrorHandler<T>) -> T
 ): Result<T> {
     var err: ZError? = null
     val outcome = runCatching {
         block(
-            ErrorHandler { je, message ->
-                err = ZError(je ?: message)
+            JniErrorHandler { je ->
+                err = ZError(je ?: "native binding error")
                 sentinel()
-            }
+            },
+            ErrorHandler { message ->
+                err = ZError(message)
+                sentinel()
+            },
         )
     }
     err?.let { return Result.failure(it) }
@@ -106,11 +120,11 @@ internal inline fun <T> zCall0(
     return outcome
 }
 
-/** Handler for non-[Result] contexts: throws [ZError] (safe — runs after the
- * native call has returned). Binds `out R` to [Nothing] so one instance
- * satisfies every wrapper. */
+/** Domain handler for non-[Result] contexts: throws [ZError] (safe — runs after
+ * the native call has returned). Binds `out R` to [Nothing] so one instance
+ * satisfies every wrapper; paired with [throwZError0] as the `onBindingError`. */
 internal val throwZError: ErrorHandler<Nothing> =
-    ErrorHandler { je, message -> throw ZError(je ?: message) }
+    ErrorHandler { message -> throw ZError(message) }
 
 /** [throwZError] twin for binding-only-fallible wrappers. */
 internal val throwZError0: JniErrorHandler<Nothing> =

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -19,6 +19,7 @@ import io.zenoh.exceptions.throwZError
 import io.zenoh.exceptions.throwZError0
 import io.zenoh.exceptions.zCall
 import io.zenoh.jni.ErrorHandler
+import io.zenoh.jni.JniErrorHandler
 import io.zenoh.jni.keyexpr.KeyExpr as JniKeyExpr
 import io.zenoh.session.SessionDeclaration
 
@@ -80,7 +81,7 @@ class KeyExpr internal constructor(
     private inline fun <R> withHandle(body: (JniKeyExpr) -> R): R {
         val h = jniKeyExpr
         if (h != null) return body(h)
-        val tmp = JniKeyExpr.newTryFrom(keyExpr, throwZError)
+        val tmp = JniKeyExpr.newTryFrom(keyExpr, throwZError0, throwZError)
         try {
             return body(tmp)
         } finally {
@@ -96,8 +97,10 @@ class KeyExpr internal constructor(
          * (binding-only) string read failure both surface as
          * [Result.failure].
          */
-        private inline fun fromProbe(crossinline makeProbe: (ErrorHandler<JniKeyExpr>) -> JniKeyExpr): Result<KeyExpr> =
-            zCall({ JniKeyExpr(0L) }) { makeProbe(it) }
+        private inline fun fromProbe(
+            crossinline makeProbe: (JniErrorHandler<JniKeyExpr>, ErrorHandler<JniKeyExpr>) -> JniKeyExpr
+        ): Result<KeyExpr> =
+            zCall({ JniKeyExpr(0L) }) { onBindingError, onError -> makeProbe(onBindingError, onError) }
                 .mapCatching { probe ->
                     try {
                         KeyExpr(probe.getStr(throwZError0))
@@ -122,7 +125,9 @@ class KeyExpr internal constructor(
          * @return a [Result] with the [KeyExpr] in case of success.
          */
         fun tryFrom(keyExpr: String): Result<KeyExpr> =
-            zCall({ JniKeyExpr(0L) }) { JniKeyExpr.newTryFrom(keyExpr, it) }
+            zCall({ JniKeyExpr(0L) }) { onBindingError, onError ->
+                JniKeyExpr.newTryFrom(keyExpr, onBindingError, onError)
+            }
                 .map { probe ->
                     probe.close()
                     KeyExpr(keyExpr)
@@ -138,7 +143,9 @@ class KeyExpr internal constructor(
          * @return a [Result] with the canonized [KeyExpr] in case of success.
          */
         fun autocanonize(keyExpr: String): Result<KeyExpr> =
-            fromProbe { JniKeyExpr.newAutocanonize(keyExpr, it) }
+            fromProbe { onBindingError, onError ->
+                JniKeyExpr.newAutocanonize(keyExpr, onBindingError, onError)
+            }
     }
 
     /**
@@ -176,18 +183,18 @@ class KeyExpr internal constructor(
      * Joins both sides, inserting a `/` in between them.
      * This should be your preferred method when concatenating path segments.
      */
-    fun join(other: String): Result<KeyExpr> = fromProbe { onError ->
-        jniKeyExpr?.let { JniKeyExpr.newJoin(it, other, onError) }
-            ?: JniKeyExpr.newJoin(keyExpr, other, onError)
+    fun join(other: String): Result<KeyExpr> = fromProbe { onBindingError, onError ->
+        jniKeyExpr?.let { JniKeyExpr.newJoin(it, other, onBindingError, onError) }
+            ?: JniKeyExpr.newJoin(keyExpr, other, onBindingError, onError)
     }
 
     /**
      * Performs string concatenation and returns the result as a `KeyExpr` if possible.
      * You should probably prefer [join] as Zenoh may then take advantage of the hierarchical separation it inserts.
      */
-    fun concat(other: String): Result<KeyExpr> = fromProbe { onError ->
-        jniKeyExpr?.let { JniKeyExpr.newConcat(it, other, onError) }
-            ?: JniKeyExpr.newConcat(keyExpr, other, onError)
+    fun concat(other: String): Result<KeyExpr> = fromProbe { onBindingError, onError ->
+        jniKeyExpr?.let { JniKeyExpr.newConcat(it, other, onBindingError, onError) }
+            ?: JniKeyExpr.newConcat(keyExpr, other, onBindingError, onError)
     }
 
     override fun toString(): String {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/liveliness/Liveliness.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/liveliness/Liveliness.kt
@@ -51,10 +51,10 @@ class Liveliness internal constructor(private val session: Session) {
      */
     fun declareToken(keyExpr: KeyExpr): Result<LivelinessToken> {
         val jniSession = session.jniSession ?: return Result.failure(Session.sessionClosedException)
-        return zCall({ JniLivelinessToken(0L) }) { onError ->
+        return zCall({ JniLivelinessToken(0L) }) { onBindingError, onError ->
             jniSession.livelinessDeclareToken(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
-                onError
+                onBindingError, onError
             )
         }.map { LivelinessToken(it) }
     }
@@ -170,13 +170,13 @@ class Liveliness internal constructor(private val session: Session) {
         timeout: Duration
     ): Result<R> {
         val jniSession = session.jniSession ?: return Result.failure(Session.sessionClosedException)
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             jniSession.livelinessGet(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.jniHandle,
                 timeout.toMillis(),
                 replyCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { receiver }
     }
@@ -189,13 +189,13 @@ class Liveliness internal constructor(private val session: Session) {
         history: Boolean
     ): Result<Subscriber<R>> {
         val jniSession = session.jniSession ?: return Result.failure(Session.sessionClosedException)
-        return zCall({ JniSubscriber(0L) }) { onError ->
+        return zCall({ JniSubscriber(0L) }) { onBindingError, onError ->
             jniSession.livelinessDeclareSubscriber(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 history,
                 sampleCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { Subscriber(keyExpr, receiver, it) }
     }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/Publisher.kt
@@ -91,12 +91,12 @@ class Publisher internal constructor(
         // When no per-put encoding override is given, the publisher's default
         // encoding — set NATIVELY at declare time — applies, so no encoding
         // data crosses (the selector arm is "absent", -1).
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             p.put(
                 payload.into().bytes,
                 encoding.jniSel, encoding.jniId, encoding.jniSchema, encoding.jniHandle,
                 attachment?.into()?.bytes,
-                onError
+                onBindingError, onError
             )
         }
     }
@@ -109,8 +109,8 @@ class Publisher internal constructor(
      */
     fun delete(attachment: IntoZBytes? = null): Result<Unit> {
         val p = jniPublisher ?: return InvalidPublisherResult
-        return zCallUnit { onError ->
-            p.delete(attachment?.into()?.bytes, onError)
+        return zCallUnit { onBindingError, onError ->
+            p.delete(attachment?.into()?.bytes, onBindingError, onError)
         }
     }
 

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Querier.kt
@@ -188,7 +188,7 @@ class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private v
         encoding: Encoding?
     ): Result<R> {
         val q = jniQuerier ?: return Result.failure(ZError("Querier is not valid."))
-        return zCallUnit { onError ->
+        return zCallUnit { onBindingError, onError ->
             q.get(
                 parameters?.toString(),
                 payload?.into()?.bytes,
@@ -196,7 +196,7 @@ class Querier internal constructor(val keyExpr: KeyExpr, val qos: QoS, private v
                 attachment?.into()?.bytes,
                 replyCallbackOf { callback.run(it) },
                 { onClose() },
-                onError
+                onBindingError, onError
             )
         }.map { receiver }
     }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/query/Query.kt
@@ -81,7 +81,7 @@ class Query internal constructor(
         attachment: IntoZBytes? = null
     ): Result<Unit> {
         val q = jniQuery ?: return Result.failure(ZError("Query is invalid"))
-        val result = zCallUnit { onError ->
+        val result = zCallUnit { onBindingError, onError ->
             q.replySuccess(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.jniHandle,
                 payload.into().bytes,
@@ -89,7 +89,7 @@ class Query internal constructor(
                 timestamp?.ntpValue(),
                 attachment?.into()?.bytes,
                 qos.express,
-                onError
+                onBindingError, onError
             )
         }
         // Single-reply model: dropping the native query finalizes the reply
@@ -148,11 +148,11 @@ class Query internal constructor(
      */
     fun replyErr(error: IntoZBytes, encoding: Encoding = Encoding.default()): Result<Unit> {
         val q = jniQuery ?: return Result.failure(ZError("Query is invalid"))
-        val result = zCallUnit { onError ->
+        val result = zCallUnit { onBindingError, onError ->
             q.replyError(
                 error.into().bytes,
                 encoding.jniSel, encoding.jniId, encoding.jniSchema, encoding.jniHandle,
-                onError
+                onBindingError, onError
             )
         }
         q.close()
@@ -183,13 +183,13 @@ class Query internal constructor(
         attachment: IntoZBytes? = null
     ): Result<Unit> {
         val q = jniQuery ?: return Result.failure(ZError("Query is invalid"))
-        val result = zCallUnit { onError ->
+        val result = zCallUnit { onBindingError, onError ->
             q.replyDelete(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.jniHandle,
                 timestamp?.ntpValue(),
                 attachment?.into()?.bytes,
                 qos.express,
-                onError
+                onBindingError, onError
             )
         }
         q.close()

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QueryableTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/QueryableTest.kt
@@ -28,6 +28,7 @@ import io.zenoh.sample.Sample
 import io.zenoh.sample.SampleKind
 import io.zenoh.query.Selector
 import io.zenoh.exceptions.throwZError
+import io.zenoh.exceptions.throwZError0
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -121,7 +122,7 @@ class QueryableTest {
             null,                           // attachment
             replyCallbackOf { reply = it },
             {},                             // onClose
-            throwZError,
+            throwZError0, throwZError,
         )
         sleep(1000)
 


### PR DESCRIPTION
## What

Migrates the SDK to zenoh-flat-jni's split error-handler API ([prebindgen #45](https://github.com/milyin/prebindgen/pull/128), [zenoh-flat-jni PR](https://github.com/ZettaScaleLabs/zenoh-flat-jni/pull/10)).

The generated flat wrappers now split the error callback into two channels: the binding `JniErrorHandler.run(je)` (unchanged) and the typed domain `ErrorHandler.run(message)` (`je` **removed**, called only on a domain `Err`). A fallible wrapper takes both — `onBindingError` then `onError`.

## Changes

`exceptions/ResultHandlers.kt`:
- `zCall` / `zCallUnit` blocks change from `(ErrorHandler<T>) -> T` to `(JniErrorHandler<T>, ErrorHandler<T>) -> T`; the helper supplies **both** handlers — each records the error into the shared `err` local, and both produce the born-closed sentinel where the return type demands one.
- `throwZError` → the 1-arg domain handler `ErrorHandler { message -> throw ZError(message) }`.
- `zCall0` / `zCallUnit0` / `throwZError0` (the binding-only channel) are unchanged.

**Call sites:** every `zCall`/`zCallUnit` block threads both handlers into its flat wrapper call across `Config`/`Session`/`Zenoh`/`KeyExpr`/`Liveliness`/`Publisher`/`Querier`/`Query`. `KeyExpr.fromProbe` gains the binding param and its callers (`join`/`concat`/`tryFrom`/`autocanonize`/`withHandle`) thread both. The two direct `throwZError` passes (`KeyExpr.withHandle`, a `commonTest` reply) gain `throwZError0`. Binding-only calls (`zCall0`/`throwZError0`/`newClone`/the keyexpr algebra ops) are untouched.

## Validation

Builds against the local composite `zenoh-flat-jni` (its `split-error-handler` branch) with Gradle 8.12.1; **117 jvmTest tests pass** (12 skipped), including the `Result` error paths that prove a zenoh error still surfaces as `Result.failure(ZError)`.

Depends on the zenoh-flat-jni split-error-handler PR merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)