### PR TITLE
Enable unsigned + Pair/Triple serialization via the KType path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: 249fe9e34ac5d05bc442355fd216a324114e2621
+          ref: 9503f73994c85850354684c0ea9867c5ac93d454
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat

--- a/ZENOH_FLAT_TRANSITION.md
+++ b/ZENOH_FLAT_TRANSITION.md
@@ -52,9 +52,11 @@ the sink reports those without throwing.
 
 Planned follow-ups on this branch:
 
-- KType-aware serializer in the zenoh-flat-jni shared tier
+- ~~KType-aware serializer in the zenoh-flat-jni shared tier
   (restores `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` support in
-  `zSerialize`/`zDeserialize`).
+  `zSerialize`/`zDeserialize`).~~ **Done** — zenoh-flat-jni gained a KType path
+  (`serializeViaJNIKType`/`deserializeViaJNIKType`) alongside the Java
+  `Type` path; `zSerialize`/`zDeserialize` pass the full `KType`.
 - Advanced pub/sub (`AdvancedPublisher`/`AdvancedSubscriber`, matching and
   sample-miss listeners) surface in zenoh-flat → zenoh-flat-jni, replacing the
   temporary failing stubs.

--- a/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ZBytesTest.kt
+++ b/zenoh-kotlin/src/commonTest/kotlin/io/zenoh/ZBytesTest.kt
@@ -18,14 +18,8 @@ import io.zenoh.ext.zDeserialize
 import io.zenoh.ext.zSerialize
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertTrue
-
-// TODO(zenoh-flat-transition): the tests below marked with @Ignore exercise the
-// Kotlin-specific serializer types (UByte/UShort/UInt/ULong/Pair/Triple) that
-// the zenoh-flat-jni shared serializer does not support yet; they are disabled
-// until a KType-aware serializer lands upstream.
 
 class ZBytesTests {
 
@@ -110,7 +104,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test UByte serialization and deserialization`() {
         val ubyteInput: UByte = 100u
         val payload = zSerialize(ubyteInput).getOrThrow()
@@ -119,7 +112,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test UShort serialization and deserialization`() {
         val ushortInput: UShort = 300u
         val payload = zSerialize(ushortInput).getOrThrow()
@@ -128,7 +120,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test UInt serialization and deserialization`() {
         val uintInput: UInt = 123456789u
         val payload = zSerialize(uintInput).getOrThrow()
@@ -137,7 +128,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test ULong serialization and deserialization`() {
         val ulongInput: ULong = 9876543210uL
         val payload = zSerialize(ulongInput).getOrThrow()
@@ -146,7 +136,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test Pair serialization and deserialization`() {
         val pairInput = Pair(42, 0.5)
         val payload = zSerialize(pairInput).getOrThrow()
@@ -155,7 +144,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test Triple serialization and deserialization`() {
         val tripleInput = Triple(42, 0.5, listOf(true, false))
         val payload = zSerialize(tripleInput).getOrThrow()
@@ -176,7 +164,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test map of string to ULong serialization and deserialization`() {
         val mapStringULongInput = mapOf("key1" to 1uL, "key2" to 2uL, "key3" to 3uL)
         val payload = zSerialize(mapStringULongInput).getOrThrow()
@@ -185,7 +172,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test list of maps serialization and deserialization`() {
         val listOfMapsInput = listOf(
             mapOf("key1" to 1uL, "key2" to 2uL),
@@ -205,7 +191,6 @@ class ZBytesTests {
     }
 
     @Test
-    @Ignore
     fun `test nested pairs serialization and deserialization`() {
         val pairInput = Pair(42, Pair(0.5, true))
         val payload = zSerialize(pairInput).getOrThrow()

--- a/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZDeserialize.kt
+++ b/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZDeserialize.kt
@@ -2,7 +2,7 @@ package io.zenoh.ext
 
 import io.zenoh.bytes.ZBytes
 import io.zenoh.exceptions.zCall0
-import io.zenoh.jni.bytes.deserializeViaJNI
+import io.zenoh.jni.bytes.deserializeViaJNIKType
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -17,10 +17,16 @@ import kotlin.reflect.typeOf
  * - [Long]
  * - [Float]
  * - [Double]
+ * - [UByte]
+ * - [UShort]
+ * - [UInt]
+ * - [ULong]
  * - [List]
  * - [String]
  * - [ByteArray]
  * - [Map]
+ * - [Pair]
+ * - [Triple]
  *
  * **NOTE**
  *
@@ -71,14 +77,11 @@ inline fun <reified T : Any> zDeserialize(zbytes: ZBytes): Result<T> =
     zDeserializeImpl(zbytes, typeOf<T>()).mapCatching { it as T }
 
 /**
- * Implementation of [zDeserialize]: bridges the [KType] to a
- * `java.lang.reflect.Type` and calls the shared (de)serializer of the flat
- * bindings tier.
- *
- * TODO(zenoh-flat-transition): the flat deserializer does not yet support the
- * Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types — those
- * deserialize requests fail until a KType-aware serializer lands upstream.
+ * Implementation of [zDeserialize]: passes the full [KType] to the shared flat
+ * bindings deserializer, which inspects the KType classifier and so supports the
+ * Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types in
+ * addition to the signed/collection types.
  */
 @PublishedApi
 internal fun zDeserializeImpl(zbytes: ZBytes, type: KType): Result<Any> =
-    zCall0<Any>({ Unit }) { deserializeViaJNI(zbytes.toBytes(), type.javaBoxedType(), it) }
+    zCall0<Any>({ Unit }) { deserializeViaJNIKType(zbytes.toBytes(), type, it) }

--- a/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZSerialize.kt
+++ b/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZSerialize.kt
@@ -2,10 +2,8 @@ package io.zenoh.ext
 
 import io.zenoh.bytes.ZBytes
 import io.zenoh.exceptions.zCall0
-import io.zenoh.jni.bytes.serializeViaJNI
-import java.lang.reflect.Type
+import io.zenoh.jni.bytes.serializeViaJNIKType
 import kotlin.reflect.KType
-import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
 /**
@@ -19,10 +17,16 @@ import kotlin.reflect.typeOf
  * - [Long]
  * - [Float]
  * - [Double]
+ * - [UByte]
+ * - [UShort]
+ * - [UInt]
+ * - [ULong]
  * - [List]
  * - [String]
  * - [ByteArray]
  * - [Map]
+ * - [Pair]
+ * - [Triple]
  *
  * **NOTE**
  *
@@ -72,29 +76,12 @@ import kotlin.reflect.typeOf
 inline fun <reified T : Any> zSerialize(t: T): Result<ZBytes> = zSerializeImpl(t, typeOf<T>())
 
 /**
- * Implementation of [zSerialize]: bridges the [KType] to a `java.lang.reflect.Type`
- * and calls the shared (de)serializer of the flat bindings tier.
- *
- * TODO(zenoh-flat-transition): the flat serializer does not yet support the
- * Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types — those
- * serialize requests fail until a KType-aware serializer lands upstream.
+ * Implementation of [zSerialize]: passes the full [KType] to the shared flat
+ * bindings serializer, which inspects the KType classifier and so supports the
+ * Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types in
+ * addition to the signed/collection types.
  */
 @PublishedApi
-@OptIn(ExperimentalStdlibApi::class)
 internal fun zSerializeImpl(t: Any, type: KType): Result<ZBytes> =
-    zCall0({ ByteArray(0) }) { serializeViaJNI(t, type.javaBoxedType(), it) }
+    zCall0({ ByteArray(0) }) { serializeViaJNIKType(t, type, it) }
         .map { ZBytes.from(it) }
-
-/**
- * The [java.lang.reflect.Type] of this [KType], with a top-level primitive
- * boxed to its wrapper class: `typeOf<Int>().javaType` is the primitive
- * `int`, but the shared serializer works on reference types
- * (`java.lang.Integer`, …) — as the generic positions (where boxing is
- * inherent) already do.
- */
-@PublishedApi
-@OptIn(ExperimentalStdlibApi::class)
-internal fun KType.javaBoxedType(): Type {
-    val jt = javaType
-    return if (jt is Class<*> && jt.isPrimitive) jt.kotlin.javaObjectType else jt
-}


### PR DESCRIPTION
## What

zenoh-flat-jni now exposes a **KType-aware serializer** ([zenoh-flat-jni#12](https://github.com/ZettaScaleLabs/zenoh-flat-jni/pull/12)). Switch the `zSerialize`/`zDeserialize` bridge from the erased `.javaType` (`serializeViaJNI`/`deserializeViaJNI`) to passing the full `KType` (`serializeViaJNIKType`/`deserializeViaJNIKType`), so the Kotlin-native `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types work.

- Delete the `javaBoxedType()` bridge (the `KType` is passed directly now) and the transition TODOs; update the supported-types KDoc.
- Un-`@Ignore` the 9 `ZBytesTest` cases (unsigned / `Pair` / `Triple` / nested).

## Verification

Full `jvmTest`: **117 pass** — skipped dropped from 12 to 3 (the 9 serializer tests are now green; only the advanced pub/sub suite remains skipped, pending its own follow-up). Built against the local composite zenoh-flat-jni (`ktype-serializer`).

## Notes

- The first of the two `ZENOH_FLAT_TRANSITION.md` serializer follow-ups (struck in this PR); advanced pub/sub is the remaining one.
- **Stacked on #673** (the split error-handler migration) — this branch is based on `split-error-handler` and targets it, so the diff here is just the serializer change. CI pin bumped to the zenoh-flat-jni serializer commit.
- **Kotlin-only by design**: zenoh-java's serializer is Guava-`TypeToken`-based and Java has no unsigned types, so it keeps the `Type` path unchanged (regression-verified: its ZBytes tests stay green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)