### PR TITLE
CI: build zenoh-flat-jni against published prebindgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,26 +31,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#23 merges.
-          ref: 227f2663b81f0dae3af15de38cd729ec29eac931
+          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#25 merges.
+          ref: bbc47c42ca91cf0578deaa272b6ad2463ae8d51d
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat
-          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat#79 merges.
-          ref: 8ca56d2bb9c00617c001928bf9b2bc564dd62071
+          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat#80 merges.
+          ref: 936fd00b4b4d6b0e2b3bf8662a275aad4adffe36
           path: zenoh-flat
-
-      - name: Use prebindgen from GitHub main
-        shell: bash
-        working-directory: zenoh-flat-jni
-        run: |
-          sed -i.bak \
-            -E -e 's|(prebindgen[a-z-]*) = \{ path = "\.\./prebindgen/[a-z-]+"|\1 = { git = "https://github.com/milyin/prebindgen.git", branch = "main"|g' \
-            Cargo.toml ../zenoh-flat/Cargo.toml
-          rm Cargo.toml.bak ../zenoh-flat/Cargo.toml.bak
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,17 @@ jobs:
       - name: Check out zenoh-flat-jni
         uses: actions/checkout@v4
         with:
-          repository: ZettaScaleLabs/zenoh-flat-jni
-          ref: 498ba268cf314b38bdca3faa131c2ee8402b2ac4
+          repository: eclipse-zenoh/zenoh-flat-jni
+          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#23 merges.
+          ref: 227f2663b81f0dae3af15de38cd729ec29eac931
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat
         uses: actions/checkout@v4
         with:
-          repository: ZettaScaleLabs/zenoh-flat
-          ref: 3f431b6b581c49b6c4d0e94fab5922f860a98205
+          repository: eclipse-zenoh/zenoh-flat
+          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat#79 merges.
+          ref: 8ca56d2bb9c00617c001928bf9b2bc564dd62071
           path: zenoh-flat
 
       - name: Use prebindgen from GitHub main
@@ -46,8 +48,7 @@ jobs:
         working-directory: zenoh-flat-jni
         run: |
           sed -i.bak \
-            -e 's|prebindgen = { path = "../prebindgen/prebindgen" }|prebindgen = { git = "https://github.com/milyin/prebindgen.git", branch = "main" }|g' \
-            -e 's|prebindgen-proc-macro = { path = "../prebindgen/prebindgen-proc-macro",|prebindgen-proc-macro = { git = "https://github.com/milyin/prebindgen.git", branch = "main",|g' \
+            -E -e 's|(prebindgen[a-z-]*) = \{ path = "\.\./prebindgen/[a-z-]+"|\1 = { git = "https://github.com/milyin/prebindgen.git", branch = "main"|g' \
             Cargo.toml ../zenoh-flat/Cargo.toml
           rm Cargo.toml.bak ../zenoh-flat/Cargo.toml.bak
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#25 merges.
-          ref: bbc47c42ca91cf0578deaa272b6ad2463ae8d51d
+          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#24 merges.
+          ref: 02feeccadc5add438af85ee64ae941d8ce6b9b38
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat
-          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat#80 merges.
-          ref: 936fd00b4b4d6b0e2b3bf8662a275aad4adffe36
+          ref: 81feb940cce9f4c3b33a87de397b2ce42cb5fc9e
           path: zenoh-flat
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          # TODO: re-pin to `main` once eclipse-zenoh/zenoh-flat-jni#24 merges.
-          ref: 02feeccadc5add438af85ee64ae941d8ce6b9b38
+          ref: 6f81eb8f9d5c49b72dda2fb054a174cce3184f2a
           path: zenoh-flat-jni
 
       - name: Check out zenoh-flat


### PR DESCRIPTION
The `zenoh-flat-jni` checkout this workflow builds no longer keeps `prebindgen` as a sibling path dependency: **prebindgen 0.5.0 is on crates.io**, so both it and `zenoh-flat` now declare plain version constraints.

That deletes the *Use prebindgen from GitHub main* step outright — the `sed` had nothing left to rewrite. What remains is the checkout re-pointing that motivated this PR originally: `ZettaScaleLabs/*` → `eclipse-zenoh/*`, both now on `main`.

| checkout | pinned to |
|---|---|
| `zenoh-flat` | `main` @ 81feb94 (eclipse-zenoh/zenoh-flat#80) |
| `zenoh-flat-jni` | `main` @ 6f81eb8 (eclipse-zenoh/zenoh-flat-jni#24) |

No TODOs left — the whole chain is merged upstream.

### Verified

`:zenoh-kotlin:jvmTest` against exactly these two trees via the local composite build: **121 tests, all pass.**