### PR TITLE
CI: pin zenoh-flat-jni to the timestamp node-id fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          ref: 6f81eb8f9d5c49b72dda2fb054a174cce3184f2a
+          # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
+          # from git, so its Cargo.lock is the pin that decides.
+          ref: 80f0d09abac4d4201842d06ad0c0791876472fae
           path: zenoh-flat-jni
-
-      - name: Check out zenoh-flat
-        uses: actions/checkout@v4
-        with:
-          repository: eclipse-zenoh/zenoh-flat
-          ref: 81feb940cce9f4c3b33a87de397b2ce42cb5fc9e
-          path: zenoh-flat
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Fixes the flaky `QueryableTest.queryable_runsWithCallback` failure seen on #669,
and takes this repo out of the business of building and linting its Rust
dependency.

## What actually failed

`Sample.equals` compares `timestamp.id`. zenoh-flat carried a timestamp's node
id trimmed to its significant bytes, while `ZenohId` carries the full
zero-padded width — the same node as two different byte strings whenever its
identifier has a high-order zero byte, i.e. about once in 256 sessions. The
failing run's zid was 15 bytes; the run that passed on the same commit had 16.

The visible difference in the assertion message is the *encoding*
(`unknown(0)` vs `zenoh/bytes`) and it is a red herring: `Encoding.equals`
compares `id` and `schema`, not the description, so those two compare equal.
Only the padding of the id differs, and it renders identically on both sides.

Fixed upstream in eclipse-zenoh/zenoh-flat#86, picked up by
eclipse-zenoh/zenoh-flat-jni#35, which this pins.

## Why the ci.yml zenoh-flat pin did not already cover it

It never pinned anything: nothing reads that sibling checkout. zenoh-flat-jni
resolves zenoh-flat from git, so *its* `Cargo.lock` is the rev that decides —
and it still pointed at the pre-fix commit, which happened to be the same SHA
the dead step named. The step is dropped here.

## The Rust part of this workflow

Also dropped: the hardcoded `1.93.0` toolchain and the `cargo build` step.

zenoh-flat-jni pins its own toolchain in `rust-toolchain.toml` (now 1.97.1), so
naming a version here can only drift out of agreement with it — that drift is
exactly what broke the sibling zenoh-java workflow, where the same step added
rustfmt to 1.93.0 while the checks ran on the pinned toolchain. `rustup show`,
run from the zenoh-flat-jni directory, installs whatever that repo pins.

`cargo build` was redundant: the composite build's test task depends on
zenoh-flat-jni's native build, so Gradle drives cargo. Verified by deleting the
built dylib and running `jvmTest`, which rebuilt it and passed.

**Can the Rust part go entirely?** Not yet, and not because of the toolchain:
`org.eclipse.zenoh:zenoh-flat-jni` is not on Maven Central yet, and these
branches test against bindings that are ahead of any release anyway — the
composite build exists precisely to bridge that gap. Once a zenoh-flat-jni
release carries this fix, CI can drop `-PuseLocalFlatJni=true`, and with it the
sibling checkout and every Rust step, resolving the artifact like any other
consumer.

## Verification

Against this zenoh-flat-jni checkout through the Gradle composite build, the
full `jvmTest` suite passes (121 tests). The fix itself is covered
deterministically upstream by `id_matches_zenoh_id_bytes` in zenoh-flat; a
Kotlin-side test would only reproduce once in 256 runs. zenoh-flat-jni#35 is
green on all three platforms.