### PR TITLE
CI: track zenoh-flat-jni main, and let Gradle drive its native build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           repository: eclipse-zenoh/zenoh-flat-jni
           # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
           # from git, so its Cargo.lock is the pin that decides.
-          ref: 80f0d09abac4d4201842d06ad0c0791876472fae
+          ref: e75529ce3758401ce213456e7b8e4e5667635cf8
           path: zenoh-flat-jni
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh-flat-jni
-          # zenoh-flat is not checked out here: zenoh-flat-jni resolves it
-          # from git, so its Cargo.lock is the pin that decides.
-          ref: e75529ce3758401ce213456e7b8e4e5667635cf8
+          # No ref: track that repository's default branch. A pinned commit has
+          # to be hand-edited for every upstream fix, and this is the one hop
+          # in the chain no bot covers - zenoh-flat-jni's own Cargo.lock is
+          # kept aligned with zenoh for it, so following its main keeps the
+          # whole chain automatic. zenoh-flat is not checked out at all: it is
+          # resolved from git by that lockfile.
           path: zenoh-flat-jni
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,25 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      # zenoh-flat-jni pins its toolchain in rust-toolchain.toml. Install it
+      # from that directory, so a missing toolchain fails here rather than
+      # inside the Gradle build - and so this repo never has to name a version
+      # its dependency is free to change.
       - name: Install Rust toolchain
-        run: |
-          rustup show
-          rustup component add rustfmt clippy --toolchain 1.93.0
-
-      - name: Build zenoh-flat-jni
         working-directory: zenoh-flat-jni
-        run: cargo build
+        run: rustup show
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: Gradle Test
         working-directory: zenoh-kotlin
-        # CI builds against the sibling checkouts above, so it opts into the
+        # CI builds against the sibling checkout above, so it opts into the
         # composite build. A release does not: it resolves zenoh-flat-jni from
         # Maven Central like any other consumer.
+        #
+        # No cargo step precedes this: the composite build's test task depends
+        # on zenoh-flat-jni's own native build, so Gradle drives cargo.
         run: ./gradlew jvmTest --info -PuseLocalFlatJni=true
 
   markdown_lint:


### PR DESCRIPTION
Follow-up to #698, which merged before this was pushed. Two changes, both about
this repository doing less to its Rust dependency.

## Track zenoh-flat-jni's default branch, drop the pinned SHA

The checkout step named an exact zenoh-flat-jni commit, which has to be
hand-edited for every upstream fix — the one hop in the chain no bot covers.
The timestamp node-id flake fixed by #698 is what that costs: the fix was
upstream while CI here kept testing the commit the pin named.

*(Superseded by the follow-up that puts the pin back in a file a bot can rewrite
— tracking `main` gave up reproducibility, which `Cargo.lock` never does.)*

## Let Gradle drive the native build

The workflow also added rustfmt and clippy to a hardcoded `1.93.0` toolchain and
ran `cargo build` in the checkout. Neither is needed.

zenoh-flat-jni pins its own toolchain in `rust-toolchain.toml` (now 1.97.1), so
naming a version here can only drift out of agreement with it — not
hypothetical: the same step in the sibling zenoh-java workflow put rustfmt on
1.93.0 while `cargo fmt --check` ran under the pinned toolchain, and the bump
from #698 turned it into `'cargo-fmt' is not installed for the toolchain
'1.97.1'` (eclipse-zenoh/zenoh-java#520). `rustup show`, run from the
zenoh-flat-jni directory, installs whatever that repository pins.

`cargo build` was redundant: the composite build's test task depends on
zenoh-flat-jni's native build, so Gradle drives cargo. Verified by deleting the
built `libzenoh_flat_jni.so` and running `jvmTest` — it rebuilt the dylib and
passed.