### PR TITLE
Build main against zenoh-flat-jni's snapshot, not an unreleased version

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -86,8 +86,9 @@ Central, because:
   a binding version that never materializes cannot be repaired, only superseded.
 
 `ci/scripts/bump-and-tag.bash` enforces the first half: it refuses to run a
-**live** release against a `-SNAPSHOT` binding version. A rehearsal is allowed
-to, which is what makes the transition workable — see
+**live** release against a `-SNAPSHOT` binding version — including the one
+`gradle.properties` carries by default, so a live release has to name a real
+one. A rehearsal is allowed to, which is what makes the transition workable — see
 [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released).
 
 ## Running a release
@@ -113,7 +114,7 @@ builds and publishes.
 | --- | --- |
 | `live-run` | **unchecked** |
 | `version` | a fresh provisional number, not one already used |
-| `zenoh-flat-jni-version` | a version that exists — today a snapshot, see [below](#rehearsing-the-release-workflow-with-a-snapshot). Empty falls back to `gradle.properties`, which names an unreleased version and fails |
+| `zenoh-flat-jni-version` | empty is fine — `gradle.properties` names the snapshot zenoh-flat-jni publishes from main. Fill it in only to rehearse against a specific version, see [below](#rehearsing-the-release-workflow-with-a-snapshot) |
 | `maven_publish` | checked — or uncheck for the very first run |
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
@@ -162,11 +163,13 @@ release is blocked.
 | live release | `zenoh-flat-jni:<version>` on Central | **blocked until that exists** |
 
 A snapshot may depend on a snapshot, because nothing published is permanent. So
-the answer is to consume the snapshot that zenoh-flat-jni's *own* rehearsal
-published — a rehearsal there with `maven_publish` enabled uploads
-`zenoh-flat-jni:<version>-SNAPSHOT` to the Central snapshot repository.
+this is what `gradle.properties` already names: `zenoh-flat-jni`'s CI publishes
+`<version>-SNAPSHOT` from its `main` to the Central snapshot repository, and
+`zenohFlatJniVersion` here points at it. Nothing needs passing on the command
+line, and — because the version ends in `-SNAPSHOT` — the snapshot repository is
+on the resolution path, which is the whole mechanism.
 
-Nothing needs editing. Name the version on the command line:
+To try a different one, name it per-invocation:
 
 ```bash
 ./gradlew build -PzenohFlatJniVersion=1.9.0-rc8-SNAPSHOT
@@ -189,22 +192,25 @@ Then run **Release** from the Actions tab with:
 | input | value |
 | --- | --- |
 | `live-run` | **unchecked** — a live run refuses a `-SNAPSHOT` binding |
-| `zenoh-flat-jni-version` | the version above, e.g. `1.9.0-rc8-SNAPSHOT` |
+| `zenoh-flat-jni-version` | empty to take `main`'s snapshot, or one of the versions above, e.g. `1.9.0-rc8-SNAPSHOT` |
 | `maven_publish` | checked to rehearse the upload too, unchecked to stop at assembly |
 | `version`, `branch` | leave empty unless you are rehearsing a specific one |
 
-**`zenoh-flat-jni-version` is the field that matters.** Left empty, the build
-falls back to `zenohFlatJniVersion` in `gradle.properties` — currently `1.9.0`,
-which is not on Maven Central, and the run dies in `compileKotlinJvm`:
+Left empty, the build falls back to `zenohFlatJniVersion` in `gradle.properties`,
+which names `main`'s snapshot — so the nightly scheduled runs of `release.yml`
+and of the snapshot publication in `ci.yml`, neither of which passes inputs,
+resolve it too.
+
+If that property ever names a version that is *not* published, the run dies in
+`compileKotlinJvm`:
 
 ```text
 Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
 ```
 
-That is the conditional repository below doing its job, not a broken build: a
-non-snapshot version never gets the snapshot repository on its resolution path.
-The same applies to the nightly scheduled run of `release.yml`, which passes no
-inputs and so fails this way until zenoh-flat-jni is released for real.
+For a non-snapshot version that is the conditional repository below doing its
+job, not a broken build: it never gets the snapshot repository on its resolution
+path, so it has to be on Maven Central for real.
 
 The Central snapshot repository is declared **conditionally** in
 `build.gradle.kts`, and this is the part worth understanding:
@@ -234,8 +240,9 @@ policy, but because the repository that serves them is not on the path.
 
 1. **`tag`** — `eclipse-zenoh/ci/create-release-branch` cuts the release branch,
    then `ci/scripts/bump-and-tag.bash` writes `version.txt`, optionally rewrites
-   `zenohFlatJniVersion` in `gradle.properties`, commits and tags. It refuses a
-   `-SNAPSHOT` binding version on a live run.
+   `zenohFlatJniVersion` in `gradle.properties`, commits and tags. A live run
+   refuses a `-SNAPSHOT` binding version — checked on what `gradle.properties`
+   ends up saying, since between releases that is a snapshot by default.
 2. **`publish`** — compiles Kotlin and publishes both artifacts in one Gradle
    invocation, so they share one staging repository and are released together.
    No native toolchain is installed and no Rust is built; both would be

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -25,19 +25,6 @@ git commit version.txt -m "chore: Bump version to \`$version\`"
 
 # Point at the zenoh-flat-jni release this SDK is built against.
 if [[ -n "$flat_jni_version" ]]; then
-  # A *release* may not depend on a snapshot: consumers do not configure the
-  # snapshot repository, and snapshots mutate and expire. A rehearsal may — that
-  # is how the SDK is exercised before the binding is released at all.
-  case "$flat_jni_version" in
-    *-SNAPSHOT)
-      if [[ "$live_run" == "true" ]]; then
-        echo "error: refusing to release against a snapshot dependency ($flat_jni_version)" >&2
-        exit 1
-      fi
-      echo "note: rehearsing against snapshot $flat_jni_version"
-      ;;
-  esac
-
   sed -i.bak -E "s|^zenohFlatJniVersion=.*|zenohFlatJniVersion=$flat_jni_version|" gradle.properties
   rm -f gradle.properties.bak
 
@@ -50,6 +37,24 @@ if [[ -n "$flat_jni_version" ]]; then
     git commit gradle.properties -m "chore: Build against zenoh-flat-jni \`$flat_jni_version\`"
   fi
 fi
+
+# Checked on the value gradle.properties ends up with, not on the input: main
+# carries a -SNAPSHOT binding between releases, so an omitted FLAT_JNI_VERSION is
+# exactly how a snapshot reaches a live release now. A *release* may not depend
+# on one — consumers do not configure the snapshot repository, and snapshots
+# mutate and expire. A rehearsal may: that is how the SDK is exercised before the
+# binding is released at all.
+readonly effective_flat_jni_version=$(sed -n 's|^zenohFlatJniVersion=||p' gradle.properties)
+case "$effective_flat_jni_version" in
+  *-SNAPSHOT)
+    if [[ "$live_run" == "true" ]]; then
+      echo "error: refusing to release against a snapshot dependency ($effective_flat_jni_version);" \
+           "pass zenoh-flat-jni-version with a release that is on Maven Central" >&2
+      exit 1
+    fi
+    echo "note: rehearsing against snapshot $effective_flat_jni_version"
+    ;;
+esac
 
 if [[ ${live_run} ]]; then
   git tag --force "$version" -m "v$version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,15 @@
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
-# The zenoh-flat-jni release this SDK is built against. Rewritten by
-# ci/scripts/bump-and-tag.bash at release time; override for a rehearsal with
-# -PzenohFlatJniVersion=1.9.0-rc3-SNAPSHOT.
-zenohFlatJniVersion=1.9.0
+# The zenoh-flat-jni build this SDK is built against, and the only thing that
+# decides whether the Central snapshot repository is on the resolution path at
+# all (build.gradle.kts). Rewritten by ci/scripts/bump-and-tag.bash at release
+# time, which refuses to leave a -SNAPSHOT here for a live run.
+#
+# Between releases this names the snapshot zenoh-flat-jni's CI publishes from
+# main: nothing is on Maven Central yet, so a released version here would leave
+# main - and its nightly snapshot publication - unable to resolve anything.
+zenohFlatJniVersion=1.9.0-SNAPSHOT
 
 # Build zenoh-flat-jni from source, as Cargo.toml says, instead of resolving the
 # published artifact. See README.md. Never enable this for a release.


### PR DESCRIPTION
## The failure

The nightly snapshot publication has never got past compiling —
[run 31464385208](https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/31464385208):

```text
Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
```

`zenohFlatJniVersion=1.9.0` names a version that is not on Maven Central. No
released version could work: nothing of `zenoh-flat-jni` is published yet. The
only builds of it that exist are snapshots, and a non-snapshot version never
gets the snapshot repository on its resolution path — by design, `build.gradle.kts`.

`#701` documented the workaround (pass `zenoh-flat-jni-version` by hand for a
rehearsal). That does not help the two runs that pass no inputs at all: the
nightly snapshot publication in `ci.yml`, and the scheduled `release.yml`.

## The change

- `zenohFlatJniVersion=1.9.0-SNAPSHOT` — the snapshot zenoh-flat-jni's CI
  publishes from its `main` (eclipse-zenoh/zenoh-flat-jni#36). It is also what
  turns on the snapshot repository here, so it is one property, not two.
- `bump-and-tag.bash` now checks the value `gradle.properties` *ends up with*
  rather than the workflow input. A live release still refuses a `-SNAPSHOT`
  binding — but an omitted `zenoh-flat-jni-version` is now exactly how one would
  reach a release, which the input-only check did not cover.
- PUBLISHING.md: the fallback resolves now, so the passages saying it fails are
  no longer true.

CI's test job is unaffected — it builds zenoh-flat-jni from source
(`-PuseLocalJni=true`) and never touches a repository.

## Merge order

After eclipse-zenoh/zenoh-flat-jni#36 has run on its `main` and published
`1.9.0-SNAPSHOT`. Until then this resolves no better than today. The mechanism
itself is verified against a snapshot that does exist:

```console
$ ./gradlew :zenoh-kotlin:dependencies --configuration jvmCompileClasspath -PzenohFlatJniVersion=1.9.0-rc8-SNAPSHOT
+--- org.eclipse.zenoh:zenoh-flat-jni:1.9.0-rc8-SNAPSHOT
|    \--- org.eclipse.zenoh:zenoh-flat-jni-jvm:1.9.0-rc8-SNAPSHOT
```

eclipse-zenoh/zenoh-java#523 is the same change.