### PR TITLE
CI: publish the zenoh-flat-jni the snapshot was built against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# A run on main publishes two coordinates from two separate uploads — our copy
+# of zenoh-flat-jni, then this SDK naming it. Nothing makes that pair atomic, so
+# runs are serialized rather than cancelled: cancelling a run mid-publication is
+# exactly what leaves the two naming different commits. Per ref, so branches do
+# not queue behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 # Third-party actions are pinned to a commit, with the version in a trailing
 # comment: a tag is mutable, and a moved tag runs code nobody reviewed. Actions
 # under eclipse-zenoh/ are ours and stay on a branch.
@@ -95,17 +104,81 @@ jobs:
       - name: Check whether all jobs pass
         run: echo '${{ toJson(needs) }}' | jq -e 'all(.result == "success")'
 
-  # Publish snapshot packages. Both coordinates come from one Gradle
-  # invocation — see .github/workflows/publish.yml.
-  publish_snapshot_package:
-    name: Publish snapshot package
+  # Everything below publishes, and only from main, on every merge there.
+  # Branches and pull requests publish nothing.
+  #
+  # The snapshot must be usable by someone who is not us, which means its
+  # zenoh-flat-jni dependency has to exist — and be the commit this SDK compiled
+  # against. It must also not wait on zenoh-flat-jni's CI. Both follow from one
+  # rule: this job publishes what it depends on. See CI.md.
+
+  # Which commit that is, and whether the copy already published is it.
+  flat_jni_pin:
+    name: Resolve the zenoh-flat-jni pin
     if: contains(fromJSON('["refs/heads/main"]'), github.ref)
     needs: ci
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.pin.outputs.commit }}
+      base: ${{ steps.pin.outputs.base }}
+      qualifier: ${{ steps.pin.outputs.qualifier }}
+      rebuild: ${{ steps.pin.outputs.rebuild }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: pin
+        run: bash ci/scripts/flat-jni-copy.bash
+
+  # Our own copy, built from that commit by zenoh-flat-jni's own publication
+  # workflow — its cross-compilation matrix is six desktop targets and four
+  # Android ABIs, and duplicating it here is how the two would drift.
+  #
+  # The workflow file is taken from its main, reviewed like any dependency;
+  # `uses:` cannot hold an expression, so the pin cannot go there. What is built
+  # is `branch:`, and that is the whole of the coupling: this needs a *file* in
+  # that repository, never a run of its CI.
+  #
+  # Half an hour when it runs, so it runs only when the pin has moved.
+  publish_flat_jni_copy:
+    name: Publish our zenoh-flat-jni copy
+    needs: flat_jni_pin
+    if: needs.flat_jni_pin.outputs.rebuild == 'true'
+    uses: eclipse-zenoh/zenoh-flat-jni/.github/workflows/publish.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      snapshot: true
+      # A called workflow runs with the caller's context, so it has to be told
+      # whose sources to check out.
+      source-repository: eclipse-zenoh/zenoh-flat-jni
+      branch: ${{ needs.flat_jni_pin.outputs.commit }}
+      version-qualifier: ${{ needs.flat_jni_pin.outputs.qualifier }}
+      # It derives the coordinate from its own version.txt; this is what we
+      # expect that to be, so a pin that moved past a version bump there fails
+      # before publishing something we cannot resolve.
+      expected-base-version: ${{ needs.flat_jni_pin.outputs.base }}
+    secrets: inherit
+
+  # Then the SDK snapshot, naming the copy above. Reached both ways: the copy
+  # was rebuilt, or it was already current and skipped.
+  publish_snapshot_package:
+    name: Publish snapshot package
+    needs: [flat_jni_pin, publish_flat_jni_copy]
+    if: >-
+      ${{ !cancelled()
+          && needs.flat_jni_pin.result == 'success'
+          && needs.publish_flat_jni_copy.result != 'failure' }}
     uses: ./.github/workflows/publish.yml
     permissions:
       contents: read
       packages: write
     with:
       snapshot: true
-      branch: ${{ github.ref_name }}
+      # The commit that triggered this run, not `main`. Concurrency queues a
+      # newer run; it does not hold the branch still. Passing the branch name,
+      # this job would check out whatever `main` had become while the JNI copy
+      # was being built for half an hour — publishing SDK source B against the
+      # copy built from A's pin, which is the mismatch the whole job exists to
+      # prevent.
+      branch: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,34 @@
 name: CI
 
 on:
+  # `release/*` because that is where a release is actually built from: the
+  # release workflow creates the branch through the shared
+  # eclipse-zenoh/ci/create-release-branch action, and without this CI never runs
+  # on it. The dry-run branches that same action produces are excluded - they are
+  # throwaway.
   push:
-    branches: ["**"]
+    branches: ["main", "release/*", "!release/dry-run/*"]
+  # Every branch, not just main: a backport pull request targets a release
+  # branch, and it needs CI as much as any other. Not `push` on every branch as
+  # well - with this on, that runs the whole matrix twice per branch.
   pull_request:
     branches: ["**"]
-  schedule:
-    - cron: "0 6 * * 1-5"
+  # No schedule. The obvious argument for a nightly is that it would catch
+  # zenoh-flat-jni moving under us, and it would not: Cargo.lock pins that
+  # dependency to a commit, and Cargo re-resolves a git dependency only on
+  # `cargo update`, so a timed build rebuilds exactly what the last merge built.
+  # Upstream drift arrives here as a lockfile-sync pull request, which runs CI
+  # like anything else. What is left is an expired Central token or GPG key,
+  # caught only in a week with no merges at all - a thin canary against a daily
+  # publication. workflow_dispatch runs the path on demand.
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
+# Third-party actions are pinned to a commit, with the version in a trailing
+# comment: a tag is mutable, and a moved tag runs code nobody reviewed. Actions
+# under eclipse-zenoh/ are ours and stay on a branch.
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -23,11 +40,11 @@ jobs:
 
     steps:
       - name: Check out zenoh-kotlin
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: zenoh-kotlin
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 11
@@ -40,7 +57,7 @@ jobs:
         run: rustup show
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Gradle Test
         working-directory: zenoh-kotlin
@@ -58,8 +75,8 @@ jobs:
   markdown_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v18
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0 # v18
         with:
           config: '.markdownlint.yaml'
           globs: '**/README.md'

--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -21,19 +21,19 @@ jobs:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Build doc
         run: ./gradlew dokkaGenerate
 
       - name: Deploy doc
         if: ${{ inputs.live-run || false }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./zenoh-kotlin/build/dokka/html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,17 +35,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       # Assembles both artifacts and generates their POMs without uploading, so
       # a `maven_publish: false` rehearsal actually proves something. Only the
@@ -81,7 +81,7 @@ jobs:
 
       - name: "Upload gradle problems report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: problem-reports-${{ github.job }}.zip
           path: ${{ github.workspace }}/build/reports/problems/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
         description: "If the publication is for a snapshot version."
         default: false
       branch:
-        description: Target branch
+        description: Branch, tag or commit to publish from
         type: string
         required: false
       maven_publish:
@@ -50,8 +50,14 @@ jobs:
       # Assembles both artifacts and generates their POMs without uploading, so
       # a `maven_publish: false` rehearsal actually proves something. Only the
       # remote upload below is gated.
+      #
+      # `--refresh-dependencies` because zenohFlatJniVersion is a snapshot that
+      # the job before this one may have just replaced. Gradle caches changing
+      # modules for 24 hours and setup-gradle restores that cache, so without it
+      # this could compile against yesterday's copy while publishing a POM that
+      # names the coordinate now holding today's.
       - name: Assemble and verify the publications
-        run: ./gradlew publishJvmPublicationToMavenLocal publishAndroidReleasePublicationToMavenLocal --info -Pandroid=true
+        run: ./gradlew publishJvmPublicationToMavenLocal publishAndroidReleasePublicationToMavenLocal --info --refresh-dependencies -Pandroid=true
 
       - name: Set pub mode env var
         # Note: This step is intended to allow publishing snapshot packages.
@@ -70,7 +76,8 @@ jobs:
         run: |
           ./gradlew publishJvmPublicationToSonatypeRepository \
                     publishAndroidReleasePublicationToSonatypeRepository \
-                    ${{ env.RELEASE }} --info -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
+                    ${{ env.RELEASE }} --info --refresh-dependencies \
+                    -PremotePublication=true -Pandroid=true ${{ env.PUB_MODE }}
         env:
           CENTRAL_SONATYPE_TOKEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
           CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
@@ -85,3 +92,41 @@ jobs:
         with:
           name: problem-reports-${{ github.job }}.zip
           path: ${{ github.workspace }}/build/reports/problems/
+
+  # Everything above runs inside this repository's own build. What a user gets
+  # is the published coordinate and whatever it transitively pulls in — which is
+  # where a snapshot has failed before, by naming a zenoh-flat-jni that did not
+  # exist. So resolve it as an outsider would and run it.
+  #
+  # Snapshots only: a release goes to a staging repository and is not public at
+  # this point.
+  consumer_test:
+    name: Consume the published snapshot
+    needs: publish_package
+    if: ${{ inputs.snapshot == true && inputs.maven_publish == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      # A separate Gradle build with no path or composite dependency on this
+      # one, resolving from the snapshot repository with `--refresh-dependencies`
+      # so a cached copy of the same coordinates cannot stand in for what was
+      # just uploaded.
+      - name: Resolve and run it
+        working-directory: ci/consumer-smoke-test
+        run: |
+          set -euo pipefail
+          version="$(tr -d '[:space:]' < "$GITHUB_WORKSPACE/version.txt")-SNAPSHOT"
+          echo "Consuming org.eclipse.zenoh:zenoh-kotlin:$version" >> "$GITHUB_STEP_SUMMARY"
+          ../../gradlew run --no-daemon --refresh-dependencies -PcandidateVersion="$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,11 @@
 name: Release
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
+  # Dispatch only. The weekday schedule this had ran a dry-run release every
+  # night with no inputs, which means no `zenoh-flat-jni-version` - so it
+  # resolved the unreleased fallback in gradle.properties and died compiling,
+  # every night. A release is a deliberate act, and rehearsing one is a
+  # deliberate act too; both are `Run workflow` here. See PUBLISHING.md.
   workflow_dispatch:
     inputs:
       live-run:
@@ -58,7 +61,7 @@ jobs:
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.create-release-branch.outputs.branch }}
 

--- a/CI.md
+++ b/CI.md
@@ -11,7 +11,7 @@ source yourself, [README.md](README.md#where-the-native-library-comes-from).
 - [The pin](#the-pin)
 - [Lockfile synchronization](#lockfile-synchronization)
 - [Moving the pin by hand](#moving-the-pin-by-hand)
-- [Publishing does not use any of this](#publishing-does-not-use-any-of-this)
+- [What publishing uses](#what-publishing-uses)
 
 ## What CI runs
 
@@ -151,18 +151,37 @@ freezes resolution at a commit, so the sync can no longer move the pin and the
 bot goes silent. (The other way to defeat it — committing the `path = "…"` form —
 is covered above.)
 
-## Publishing does not use any of this
+## What publishing uses
 
-A release resolves `org.eclipse.zenoh:zenoh-flat-jni:$zenohFlatJniVersion` from
-Maven Central, like any other consumer. The pin, the lockfile and the composite
-build play no part in it — they exist so that *testing* against unreleased
-bindings is reproducible.
+A **release** does not use any of this. It resolves
+`org.eclipse.zenoh:zenoh-flat-jni:$zenohFlatJniVersion` from Maven Central like
+any other consumer; the pin, the lockfile and the composite build play no part.
+There, `zenohFlatJniVersion` says which **release** the SDK is published against
+and `Cargo.lock` says which **commit** it is tested against, and moving one does
+not move the other.
 
-The two are deliberately independent: `zenohFlatJniVersion` in
-`gradle.properties` says which **release** this SDK is built and published
-against, `Cargo.lock` says which **commit** it is tested against, and moving one
-does not move the other. A release must in fact avoid the composite build
-entirely — the artifact would be built from source on the builder's disk while
-the POM still claimed the released version — so `build.gradle.kts` fails any
-`publish*` task while an included build is present. See
+A **snapshot** makes them the same commit, by construction. It has to satisfy
+two things at once — it must publish even if zenoh-flat-jni's CI has never run,
+and the dependency it names must exist and be the code it compiled against — and
+the only construction that does both is to publish what it depends on:
+
+```text
+Cargo.lock pin ──> build zenoh-flat-jni from that commit
+                   publish it as 1.9.0-kotlin-SNAPSHOT
+                                   |
+                                   v
+                   build the SDK against that coordinate
+                   publish zenoh-kotlin:<version>-SNAPSHOT
+```
+
+So on `main`, the pin drives the publication as well as the tests, and
+`gradle.properties` names our own copy rather than a zenoh-flat-jni release.
+The mechanics — the qualifier, the commit stamp that decides whether the copy
+needs rebuilding, what the pairing does and does not guarantee — are in
+[PUBLISHING.md](PUBLISHING.md#the-snapshot-publication).
+
+Either way a publication must avoid the composite build: the artifact would be
+built from source on the builder's disk while the POM still claimed a resolved
+version, so `build.gradle.kts` fails any `publish*` task while an included build
+is present. See
 [PUBLISHING.md](PUBLISHING.md#building-against-zenoh-flat-jni-source).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "zenoh-flat-jni"
 version = "1.9.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#e75529ce3758401ce213456e7b8e4e5667635cf8"
+source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#6b5c04c8ee89422d6631f457f27ac79d2d0f3f5f"
 dependencies = [
  "jni 0.21.1",
  "konst 0.3.17",

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -203,8 +203,11 @@ Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
 
 That is the conditional repository below doing its job, not a broken build: a
 non-snapshot version never gets the snapshot repository on its resolution path.
-The same applies to the nightly scheduled run of `release.yml`, which passes no
-inputs and so fails this way until zenoh-flat-jni is released for real.
+
+`release.yml` used to run on a weekday schedule as well, and a scheduled run
+passes no inputs — so it failed exactly this way every night. The schedule is
+gone: the workflow is `workflow_dispatch` only, and a rehearsal is something you
+start on purpose, with the version filled in.
 
 The Central snapshot repository is declared **conditionally** in
 `build.gradle.kts`, and this is the part worth understanding:
@@ -246,6 +249,13 @@ policy, but because the repository that serves them is not on the path.
 
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.
+
+Every third-party action these workflows use is pinned to a **commit SHA**, with
+the version in a trailing comment — a tag is mutable, and a moved tag would run
+code nobody reviewed on a job that holds the signing key and the Central token.
+The `eclipse-zenoh/ci` actions are ours and stay on `@main` deliberately: the
+tagging and GitHub-release steps track whatever that branch holds at run time.
+Bumping a pin is an ordinary pull request; read the diff of the action first.
 
 ## Building against zenoh-flat-jni source
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -16,6 +16,8 @@ which covers them once for the whole stack.
 
 - [What this repository publishes](#what-this-repository-publishes)
 - [Relationship to zenoh-flat-jni](#relationship-to-zenoh-flat-jni)
+- [The snapshot publication](#the-snapshot-publication)
+  - [What it does not guarantee](#what-it-does-not-guarantee)
 - [Running a release](#running-a-release)
   - [Before the first run](#before-the-first-run)
   - [Rehearsal (dry run)](#rehearsal-dry-run)
@@ -86,9 +88,80 @@ Central, because:
   a binding version that never materializes cannot be repaired, only superseded.
 
 `ci/scripts/bump-and-tag.bash` enforces the first half: it refuses to run a
-**live** release against a `-SNAPSHOT` binding version. A rehearsal is allowed
-to, which is what makes the transition workable — see
+**live** release against a `-SNAPSHOT` binding version. It checks the value
+`gradle.properties` ends up with, not the workflow input: between releases that
+file names a snapshot, so *omitting* the input is the way a release would reach
+one. A rehearsal is allowed to, which is what makes the transition workable —
+see
 [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released).
+
+## The snapshot publication
+
+Between releases, every merge to `main` uploads a mutable pre-release build to
+the [Central snapshot
+repository](https://central.sonatype.com/repository/maven-snapshots/). Its
+purpose is to keep the upload machinery exercised — signing keys, credentials,
+what Central accepts — and to give people a way to try the current `main`.
+
+It publishes **five** coordinates, not two:
+
+```text
+org.eclipse.zenoh:zenoh-kotlin:<version>-SNAPSHOT
+org.eclipse.zenoh:zenoh-kotlin-android:<version>-SNAPSHOT
+org.eclipse.zenoh:zenoh-flat-jni:1.9.0-kotlin-SNAPSHOT        (+ -jvm, -android)
+```
+
+The last three are **our own copy** of zenoh-flat-jni, built from the commit
+`Cargo.lock` pins. Publishing what we depend on is what makes the snapshot both
+self-sufficient and coherent:
+
+- **self-sufficient** — if zenoh-flat-jni's CI were switched off entirely, this
+  publication still works. It uses that repository's *source at a commit we
+  choose*, never an artifact its CI produced.
+- **coherent** — the dependency our POM names is the code we compiled against.
+  Pointing instead at zenoh-flat-jni's own `1.9.0-SNAPSHOT` would name the tip
+  of *its* `main` while we compiled against our pin; JNI being a binary
+  contract, that mismatch surfaces as `UnsatisfiedLinkError` at runtime rather
+  than as a build failure.
+
+The `-kotlin` qualifier keeps our copy from overwriting the one zenoh-flat-jni
+publishes itself, or zenoh-java's — the three can legitimately pin different
+commits at the same moment. The names are fixed rather than derived from a
+commit, so each is overwritten in place and storage does not grow with the
+number of builds. (Central still stores snapshots as timestamped builds and
+cleans them after 90 days, so it is the consumer-facing *name* that is constant,
+not the bytes behind it.)
+
+Rebuilding that copy means cross-compiling ten targets, on the order of half an
+hour, and the pin moves roughly once a day — so it is rebuilt only when it has
+to be. Every POM zenoh-flat-jni publishes carries the commit it was built from:
+
+```console
+$ curl -s .../1.9.0-kotlin-SNAPSHOT/maven-metadata.xml           # ~2.9 kB
+$ curl -s .../zenoh-flat-jni-1.9.0-kotlin-<timestamp>-<n>.pom    # ~1.8 kB
+<zenoh.flatJniCommit>e75529ce…</zenoh.flatJniCommit>
+```
+
+`ci/scripts/flat-jni-copy.bash` reads that stamp from all three coordinates and
+compares it with the pin; anything missing or different means rebuild. Run it
+locally to see the decision, or `--self-test` to check its parsers.
+
+### What it does not guarantee
+
+The two uploads are separate Gradle invocations and a snapshot repository has no
+staging-and-flip, so nothing makes the pair atomic. `main`'s CI runs are
+serialized rather than cancelled — cancelling mid-publication is what splits
+them — but a failure during the second upload still leaves a split state until
+the next successful run. That is accepted for a mutable pre-release artifact;
+strict coherence would need the SDK to name an immutable, timestamped snapshot,
+which conflicts with the fixed names above.
+
+Every publication is followed by `ci/consumer-smoke-test`, a separate Gradle
+build with no connection to this one, which resolves the published
+`zenoh-kotlin:<version>-SNAPSHOT` from the snapshot repository with
+`--refresh-dependencies` and runs a key-expression round trip through JNI. That
+is the check that the whole chain — POM, transitive zenoh-flat-jni, native
+library — works for someone who is not us.
 
 ## Running a release
 
@@ -113,7 +186,7 @@ builds and publishes.
 | --- | --- |
 | `live-run` | **unchecked** |
 | `version` | a fresh provisional number, not one already used |
-| `zenoh-flat-jni-version` | a version that exists — today a snapshot, see [below](#rehearsing-the-release-workflow-with-a-snapshot). Empty falls back to `gradle.properties`, which names an unreleased version and fails |
+| `zenoh-flat-jni-version` | a version that exists — today a snapshot, see [below](#rehearsing-the-release-workflow-with-a-snapshot). Empty falls back to `gradle.properties`, which names our own `1.9.0-kotlin-SNAPSHOT` copy: fine for a rehearsal, refused for a live run |
 | `maven_publish` | checked — or uncheck for the very first run |
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
@@ -161,12 +234,15 @@ release is blocked.
 | CI, snapshot publication | `zenoh-flat-jni:<version>-SNAPSHOT` | signing, credentials, a real upload |
 | live release | `zenoh-flat-jni:<version>` on Central | **blocked until that exists** |
 
-A snapshot may depend on a snapshot, because nothing published is permanent. So
-the answer is to consume the snapshot that zenoh-flat-jni's *own* rehearsal
-published — a rehearsal there with `maven_publish` enabled uploads
-`zenoh-flat-jni:<version>-SNAPSHOT` to the Central snapshot repository.
+A snapshot may depend on a snapshot, because nothing published is permanent —
+which is what [The snapshot publication](#the-snapshot-publication) above rests
+on. `gradle.properties` names `1.9.0-kotlin-SNAPSHOT`, our own copy, and every
+merge to `main` republishes it from the pinned commit. So a rehearsal needs
+nothing set: the default already resolves.
 
-Nothing needs editing. Name the version on the command line:
+Name another one on the command line to build against a different
+zenoh-flat-jni — the snapshot it publishes itself, or one from a rehearsal
+there:
 
 ```bash
 ./gradlew build -PzenohFlatJniVersion=1.9.0-rc8-SNAPSHOT
@@ -193,21 +269,16 @@ Then run **Release** from the Actions tab with:
 | `maven_publish` | checked to rehearse the upload too, unchecked to stop at assembly |
 | `version`, `branch` | leave empty unless you are rehearsing a specific one |
 
-**`zenoh-flat-jni-version` is the field that matters.** Left empty, the build
-falls back to `zenohFlatJniVersion` in `gradle.properties` — currently `1.9.0`,
-which is not on Maven Central, and the run dies in `compileKotlinJvm`:
+**`zenoh-flat-jni-version` decides what the rehearsal builds against.** Left
+empty it falls back to `zenohFlatJniVersion` in `gradle.properties` —
+`1.9.0-kotlin-SNAPSHOT`, our own copy, which `main` republishes on every merge. A
+rehearsal against that is a real rehearsal — leaving the field empty is now a
+sound default rather than the guaranteed compile failure it used to be.
 
-```text
-Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
-```
-
-That is the conditional repository below doing its job, not a broken build: a
-non-snapshot version never gets the snapshot repository on its resolution path.
-
-`release.yml` used to run on a weekday schedule as well, and a scheduled run
-passes no inputs — so it failed exactly this way every night. The schedule is
-gone: the workflow is `workflow_dispatch` only, and a rehearsal is something you
-start on purpose, with the version filled in.
+What that fallback cannot do is reach a **live** release:
+`ci/scripts/bump-and-tag.bash` refuses a `-SNAPSHOT` binding, and it checks the
+value `gradle.properties` ends up with rather than the input, precisely because
+an omitted input now inherits one.
 
 The Central snapshot repository is declared **conditionally** in
 `build.gradle.kts`, and this is the part worth understanding:
@@ -290,9 +361,11 @@ repository.
 - **The rewritten release path has never run.** The workflows were repaired for
   a repository that no longer contains Rust; no rehearsal has yet exercised
   them.
-- **No consumer test.** Unlike zenoh-flat-jni, nothing resolves the published
-  `zenoh-kotlin` artifact from a repository and runs it before release. The
-  tests here run against the build's own output.
+- **No consumer test before a *release*.** Every snapshot publication is followed
+  by `ci/consumer-smoke-test`, which resolves the published artifact from the
+  snapshot repository and runs it — but a release goes to a staging repository
+  and is not resolvable at that point, so nothing consumes a release candidate
+  the way zenoh-flat-jni's own dry-run repository lets it consume one.
 - **No GitHub release is created.** Unlike zenoh-java, `release.yml` has no
   `publish-github` job, so a release produces Maven artifacts, a tag and updated
   documentation, but no GitHub release entry. This predates the flat-jni

--- a/README.md
+++ b/README.md
@@ -143,9 +143,13 @@ Three ways to build. Pick by what you are doing:
 | build the bindings from source too | `./gradlew build -PuseLocalJni=true` | yes |
 | build against my own checkout | `./gradlew build -PlocalJniDir=../zenoh-flat-jni` | yes |
 
-**The default** downloads `org.eclipse.zenoh:zenoh-flat-jni` from Maven Central
-with the native library already inside it. Nothing is compiled from Rust and no
-toolchain is needed.
+**The default** downloads `org.eclipse.zenoh:zenoh-flat-jni` with the native
+library already inside it. Nothing is compiled from Rust and no toolchain is
+needed. On `main` that is `1.9.0-kotlin-SNAPSHOT`, published from this repository
+alongside the SDK snapshot ([CI.md](CI.md#what-publishing-uses)); a release
+names a zenoh-flat-jni release on Maven Central. Either way it is one coordinate
+in `gradle.properties`, and if it has not been published yet the other two rows
+build without it.
 
 **`-PuseLocalJni=true`** builds the bindings from source, as `Cargo.toml`
 says — the usual Rust arrangement, and the one CI uses. A `git` dependency there

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,10 +74,12 @@ subprojects {
         google()
         mavenCentral()
 
-        // Only reachable when a snapshot of the binding was explicitly asked
-        // for, which is how this SDK is rehearsed before zenoh-flat-jni has a
-        // real release. A release version never ends in -SNAPSHOT, so a release
-        // build cannot resolve a mutable artifact.
+        // Between releases this SDK builds against a snapshot: our own copy of
+        // zenoh-flat-jni, `1.9.0-kotlin-SNAPSHOT`, published by the same job
+        // that publishes this SDK's snapshot (see CI.md). A rehearsal can name
+        // another one. Reachable only when the version asked for is a snapshot,
+        // so a release — whose version never ends in -SNAPSHOT — cannot resolve
+        // a mutable artifact by accident.
         //
         // includeGroup, not includeModule: the dependency names the root
         // coordinate, but what Gradle downloads is zenoh-flat-jni-jvm or

--- a/ci/consumer-smoke-test/build.gradle.kts
+++ b/ci/consumer-smoke-test/build.gradle.kts
@@ -1,0 +1,49 @@
+//
+// An external consumer of the published zenoh-kotlin artifact — deliberately not
+// part of the main Gradle build, with no path, project or composite dependency
+// on it. What it proves is what this repository cannot prove from inside its own
+// build: that the published coordinate resolves, that the POM's transitive
+// zenoh-flat-jni dependency exists and is resolvable too, and that the native
+// library inside it loads.
+//
+// Run against a candidate:
+//   gradle run -PcandidateVersion=<version> [-PcandidateRepository=<url>]
+//
+plugins {
+    kotlin("jvm") version "2.1.0"
+    application
+}
+
+val candidateVersion: String by project
+
+// Defaults to the Maven Central snapshot repository, which is where this
+// repository's snapshot publication puts both coordinates.
+val candidateRepository: String =
+    project.findProperty("candidateRepository")?.toString()
+        ?: "https://central.sonatype.com/repository/maven-snapshots"
+
+repositories {
+    // The content filters make the resolution source unambiguous: anything
+    // org.eclipse.zenoh can only come from the candidate repository, never from
+    // a released copy of the same coordinates on Central.
+    maven {
+        name = "candidate"
+        url = uri(candidateRepository)
+        content { includeGroup("org.eclipse.zenoh") }
+    }
+    mavenCentral {
+        content { excludeGroup("org.eclipse.zenoh") }
+    }
+}
+
+dependencies {
+    implementation("org.eclipse.zenoh:zenoh-kotlin:$candidateVersion")
+}
+
+kotlin {
+    jvmToolchain(11)
+}
+
+application {
+    mainClass.set("smoke.SmokeTestKt")
+}

--- a/ci/consumer-smoke-test/settings.gradle.kts
+++ b/ci/consumer-smoke-test/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "zenoh-kotlin-smoke-test"

--- a/ci/consumer-smoke-test/src/main/kotlin/smoke/SmokeTest.kt
+++ b/ci/consumer-smoke-test/src/main/kotlin/smoke/SmokeTest.kt
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+package smoke
+
+import io.zenoh.keyexpr.KeyExpr
+
+/**
+ * The minimum that proves a published zenoh-kotlin artifact is usable: loading
+ * the native library out of the transitive zenoh-flat-jni dependency, crossing
+ * the JNI boundary in both directions, and doing it through the API a user of
+ * this SDK actually calls.
+ *
+ * Key expressions rather than a session, because they need no network, no ports
+ * and no discovery — a CI runner cannot make them flaky.
+ */
+fun main() {
+    val expr = "demo/example/**"
+    val ke = KeyExpr.tryFrom(expr).getOrThrow()
+
+    check(ke.toString() == expr) { "key expression round-tripped as `$ke`, expected `$expr`" }
+    check(ke.intersects(KeyExpr.tryFrom("demo/example/smoke").getOrThrow())) {
+        "`$expr` should intersect `demo/example/smoke`"
+    }
+    check(!ke.intersects(KeyExpr.tryFrom("other/key").getOrThrow())) {
+        "`$expr` should not intersect `other/key`"
+    }
+
+    println(
+        "zenoh-kotlin smoke test OK on " +
+            System.getProperty("os.name") + " " + System.getProperty("os.arch")
+    )
+}

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -25,19 +25,6 @@ git commit version.txt -m "chore: Bump version to \`$version\`"
 
 # Point at the zenoh-flat-jni release this SDK is built against.
 if [[ -n "$flat_jni_version" ]]; then
-  # A *release* may not depend on a snapshot: consumers do not configure the
-  # snapshot repository, and snapshots mutate and expire. A rehearsal may — that
-  # is how the SDK is exercised before the binding is released at all.
-  case "$flat_jni_version" in
-    *-SNAPSHOT)
-      if [[ "$live_run" == "true" ]]; then
-        echo "error: refusing to release against a snapshot dependency ($flat_jni_version)" >&2
-        exit 1
-      fi
-      echo "note: rehearsing against snapshot $flat_jni_version"
-      ;;
-  esac
-
   sed -i.bak -E "s|^zenohFlatJniVersion=.*|zenohFlatJniVersion=$flat_jni_version|" gradle.properties
   rm -f gradle.properties.bak
 
@@ -50,6 +37,24 @@ if [[ -n "$flat_jni_version" ]]; then
     git commit gradle.properties -m "chore: Build against zenoh-flat-jni \`$flat_jni_version\`"
   fi
 fi
+
+# Checked on the value the release will actually build against, not on the
+# workflow input: main now inherits `1.9.0-kotlin-SNAPSHOT`, our own mutable copy
+# of zenoh-flat-jni, so omitting the input is exactly how a release would reach
+# a snapshot dependency — which the earlier input-only check did not cover.
+# A rehearsal may depend on one; that is how the SDK is exercised before the
+# binding is released at all.
+effective_flat_jni_version=$(sed -n 's/^zenohFlatJniVersion=//p' gradle.properties | tr -d '[:space:]')
+case "$effective_flat_jni_version" in
+  *-SNAPSHOT)
+    if [[ "$live_run" == "true" ]]; then
+      echo "error: refusing to release against a snapshot dependency ($effective_flat_jni_version)." >&2
+      echo "       Pass zenoh-flat-jni-version naming a release that is on Maven Central." >&2
+      exit 1
+    fi
+    echo "note: rehearsing against snapshot $effective_flat_jni_version"
+    ;;
+esac
 
 if [[ ${live_run} ]]; then
   git tag --force "$version" -m "v$version"

--- a/ci/scripts/flat-jni-copy.bash
+++ b/ci/scripts/flat-jni-copy.bash
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# Is the zenoh-flat-jni copy this repository publishes already the commit we pin?
+#
+# The SDK snapshot names org.eclipse.zenoh:zenoh-flat-jni:<qualified version>,
+# and this repository is what puts that coordinate there — built from the commit
+# Cargo.lock pins, so the dependency exists and is the code the SDK compiled
+# against, whether or not zenoh-flat-jni's CI has ever run. Producing it means
+# cross-compiling ten targets, on the order of half an hour, so it is rebuilt
+# only when the published copy is not already that commit.
+#
+# The published copy says which commit it was built from as a POM property, so
+# the check costs two small requests per coordinate rather than a 39 MB
+# download. Anything missing — no metadata, no POM, no stamp — reads as "not
+# ours" and rebuilds, which is the safe direction.
+#
+# Writes `commit`, `version`, `base`, `qualifier` and `rebuild` to $GITHUB_OUTPUT
+# when running under Actions, and prints them either way. `--self-test` runs the
+# parsers against fixtures and exits.
+#
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+readonly repository=${SNAPSHOT_REPOSITORY:-https://central.sonatype.com/repository/maven-snapshots}
+readonly group_path=org/eclipse/zenoh
+# The qualifier that keeps our copy from overwriting zenoh-flat-jni's own
+# snapshot or zenoh-java's. Checked against gradle.properties below, and
+# handed to zenoh-flat-jni's publication workflow, so the two cannot drift.
+readonly qualifier=${FLAT_JNI_QUALIFIER:-kotlin}
+# All three coordinates, not just the root: one Gradle invocation uploads them,
+# but a partial failure leaves them at different builds, and it is the platform
+# ones that carry the native libraries.
+#
+# Each with the extension of its binary, because a matching stamp is not on its
+# own proof of a finished publication. The POM goes up before the Gradle module
+# metadata and before the jar or aar, so a publication that died in between —
+# whether it was the first or an overwrite — leaves a readable stamp with no
+# module metadata for Gradle to resolve a variant against, and a decision to skip
+# rebuilding. Forever, since the next run reads the same stamp. Nothing
+# downstream would catch it either: the consumer smoke test runs on Linux, and
+# the broken variant could be the Android one.
+readonly artifacts=(
+    zenoh-flat-jni:jar
+    zenoh-flat-jni-jvm:jar
+    zenoh-flat-jni-android:aar
+)
+
+# The commit Cargo.lock pins for the git dependency on zenoh-flat-jni. Reads
+# stdin so it can be tested without a lockfile.
+pinned_commit() {
+    grep -Eom1 'zenoh-flat-jni\.git[^#"]*#[0-9a-f]{40}' | grep -Eo '[0-9a-f]{40}$'
+}
+
+# Which timestamped build a snapshot currently resolves to, from that version's
+# maven-metadata.xml on stdin:
+#   <version without -SNAPSHOT>-<timestamp>-<buildNumber>
+# It is also the middle of every file name in that build:
+#   <artifact>-<value>.<ext>
+snapshot_value() { # <version>
+    local metadata timestamp build
+    metadata=$(cat)
+    timestamp=$(sed -n 's:.*<timestamp>\(.*\)</timestamp>.*:\1:p' <<<"$metadata" | head -1)
+    build=$(sed -n 's:.*<buildNumber>\(.*\)</buildNumber>.*:\1:p' <<<"$metadata" | head -1)
+    [[ -n $timestamp && -n $build ]] || return 1
+    printf '%s-%s-%s' "${1%-SNAPSHOT}" "$timestamp" "$build"
+}
+
+# The commit a published POM on stdin was built from; empty when it has no stamp.
+pom_commit() {
+    sed -n 's:.*<zenoh\.flatJniCommit>\(.*\)</zenoh\.flatJniCommit>.*:\1:p' | head -1
+}
+
+# Whether the metadata on stdin says every one of the given extensions is at the
+# given build. Each <snapshotVersion> carries its own <value>, updated as that
+# file lands, so an overwrite that failed part-way leaves the POM at build N+1
+# while the module metadata and the binary are still at N — which is the case a
+# presence check cannot see, since all three entries exist either way and have
+# since the first publication.
+#
+# The anchor is what excludes the sources and javadoc jars: the schema puts
+# <classifier> before <extension>, so only a main artifact starts its entry with
+# the extension.
+all_at() { # <value> <extension>…
+    local blocks value ext
+    blocks=$(tr -d '[:space:]' | sed 's:<snapshotVersion>:\n:g')
+    value=${1//./\\.}
+    shift
+    for ext in "$@"; do
+        grep -q "^<extension>$ext</extension><value>$value</value>" <<<"$blocks" || return 1
+    done
+}
+
+# The stamp of the published copy of one coordinate; empty if it is not there, or
+# not all of it is at the same build.
+published_commit() { # <artifact> <version> <binary extension>
+    local base_url="$repository/$group_path/$1/$2" metadata value
+    metadata=$(curl -sf "$base_url/maven-metadata.xml") || return 0
+    value=$(snapshot_value "$2" <<<"$metadata") || return 0
+    all_at "$value" pom module "$3" <<<"$metadata" || return 0
+    # The POM is fetched by that name, so a metadata entry naming a file that
+    # never landed reads as no stamp — and rebuilds.
+    { curl -sf "$base_url/$1-$value.pom" || true; } | pom_commit
+}
+
+self_test() {
+    local got
+    got=$(pinned_commit <<<'source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#e75529ce3758401ce213456e7b8e4e5667635cf8"')
+    [[ $got == e75529ce3758401ce213456e7b8e4e5667635cf8 ]] || { echo "pinned_commit: $got" >&2; exit 1; }
+
+    # The real lockfile too, so a change to how Cargo writes it fails here
+    # rather than by silently rebuilding on every run.
+    got=$(pinned_commit <Cargo.lock)
+    [[ $got =~ ^[0-9a-f]{40}$ ]] || { echo "pinned_commit(Cargo.lock): $got" >&2; exit 1; }
+
+    got=$(snapshot_value 1.9.0-kotlin-SNAPSHOT <<'EOF'
+<versioning>
+    <snapshot>
+      <timestamp>20260810.012355</timestamp>
+      <buildNumber>1</buildNumber>
+    </snapshot>
+</versioning>
+EOF
+    )
+    [[ $got == 1.9.0-kotlin-20260810.012355-1 ]] || { echo "snapshot_value: $got" >&2; exit 1; }
+
+    # A release-style metadata carries no <snapshot> block: no build to name.
+    if snapshot_value 1.9.0 <<<'<versioning><latest>1.9.0</latest></versioning>' >/dev/null; then
+        echo "snapshot_value accepted metadata with no snapshot block" >&2
+        exit 1
+    fi
+
+    got=$(pom_commit <<<'  <zenoh.flatJniCommit>e75529ce3758401ce213456e7b8e4e5667635cf8</zenoh.flatJniCommit>')
+    [[ $got == e75529ce3758401ce213456e7b8e4e5667635cf8 ]] || { echo "pom_commit: $got" >&2; exit 1; }
+
+    got=$(pom_commit <<<'<project><version>1.9.0-kotlin-SNAPSHOT</version></project>')
+    [[ -z $got ]] || { echo "pom_commit on an unstamped POM: $got" >&2; exit 1; }
+
+    # A finished publication of build -1, in the layout zenoh-flat-jni really
+    # produces — checked against the published 1.9.0-rc8-SNAPSHOT.
+    local n=1.9.0-kotlin-20260810.012355-1
+    local finished="
+      <snapshotVersion><extension>pom</extension><value>$n</value></snapshotVersion>
+      <snapshotVersion><extension>module</extension><value>$n</value></snapshotVersion>
+      <snapshotVersion><classifier>sources</classifier><extension>jar</extension><value>$n</value></snapshotVersion>
+      <snapshotVersion><extension>jar</extension><value>$n</value></snapshotVersion>"
+    all_at "$n" pom module jar <<<"$finished" || { echo "all_at: finished rejected" >&2; exit 1; }
+    if all_at "$n" pom module aar <<<"$finished"; then
+        echo "all_at: accepted a jar publication as an aar one" >&2; exit 1
+    fi
+    if all_at "$n" pom module jar <<<"<snapshotVersion><extension>pom</extension><value>$n</value></snapshotVersion>"; then
+        echo "all_at: accepted a publication that stopped after the POM" >&2; exit 1
+    fi
+    if all_at "$n" jar <<<"<snapshotVersion><classifier>sources</classifier><extension>jar</extension><value>$n</value></snapshotVersion>"; then
+        echo "all_at: took the sources jar for the main one" >&2; exit 1
+    fi
+
+    # The case a presence check cannot see: an overwrite that replaced the POM
+    # and then failed, leaving the module metadata and the binary at the build
+    # before it. Every extension is still listed; only the values disagree.
+    local m=1.9.0-kotlin-20260811.030000-2
+    if all_at "$m" pom module jar <<<"
+      <snapshotVersion><extension>pom</extension><value>$m</value></snapshotVersion>
+      <snapshotVersion><extension>module</extension><value>$n</value></snapshotVersion>
+      <snapshotVersion><extension>jar</extension><value>$n</value></snapshotVersion>"; then
+        echo "all_at: accepted a coordinate split across two builds" >&2; exit 1
+    fi
+
+    echo "flat-jni-copy.bash self-test OK"
+}
+
+main() {
+    local version base commit rebuild=false entry artifact stamp
+    version=$(sed -n 's/^zenohFlatJniVersion=//p' gradle.properties | tr -d '[:space:]')
+    [[ $version == *-$qualifier-SNAPSHOT ]] || {
+        echo "::error::zenohFlatJniVersion=$version is not a -$qualifier-SNAPSHOT copy;" \
+             "only that coordinate is ours to publish" >&2
+        exit 1
+    }
+    # zenoh-flat-jni derives the coordinate from its own version.txt, so it needs
+    # to be told what we expect: a pin that moved past a version bump there would
+    # otherwise publish 1.10.0-kotlin-SNAPSHOT while we still resolve this.
+    base=${version%-$qualifier-SNAPSHOT}
+    commit=$(pinned_commit <Cargo.lock)
+
+    for entry in "${artifacts[@]}"; do
+        artifact=${entry%:*}
+        stamp=$(published_commit "$artifact" "$version" "${entry#*:}")
+        if [[ $stamp == "$commit" ]]; then
+            echo "$artifact:$version is already $commit"
+        else
+            echo "$artifact:$version stamp is ${stamp:-none}, want $commit"
+            rebuild=true
+        fi
+    done
+
+    echo "commit=$commit base=$base rebuild=$rebuild"
+    if [[ -n ${GITHUB_OUTPUT:-} ]]; then
+        {
+            echo "commit=$commit"
+            echo "version=$version"
+            echo "base=$base"
+            echo "qualifier=$qualifier"
+            echo "rebuild=$rebuild"
+        } >>"$GITHUB_OUTPUT"
+    fi
+}
+
+if [[ ${1:-} == --self-test ]]; then self_test; else main; fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,17 @@
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
-# The zenoh-flat-jni release this SDK is built against. Rewritten by
-# ci/scripts/bump-and-tag.bash at release time; override for a rehearsal with
+# The zenoh-flat-jni this SDK is built against. Rewritten by
+# ci/scripts/bump-and-tag.bash at release time, where it names a real Maven
+# Central release; override for a rehearsal with
 # -PzenohFlatJniVersion=1.9.0-rc3-SNAPSHOT.
-zenohFlatJniVersion=1.9.0
+#
+# Between releases it names *our own copy* of zenoh-flat-jni — the `-kotlin`
+# qualifier — built from the commit Cargo.lock pins and published by the same
+# job that publishes this SDK's snapshot. That is what makes a snapshot
+# self-sufficient: its dependency exists, and is the code it compiled against,
+# whether or not zenoh-flat-jni's CI has ever run. See CI.md.
+zenohFlatJniVersion=1.9.0-kotlin-SNAPSHOT
 
 # Build zenoh-flat-jni from source, as Cargo.toml says, instead of resolving the
 # published artifact. See README.md. Never enable this for a release.


### PR DESCRIPTION
## The failure

The snapshot publication has never got past compiling. `gradle.properties` names
`org.eclipse.zenoh:zenoh-flat-jni:1.9.0`, and nothing of `zenoh-flat-jni` has
ever been published under that version — in any form:

```text
Could not find org.eclipse.zenoh:zenoh-flat-jni:1.9.0
```

This is the zenoh-kotlin half of eclipse-zenoh/zenoh-java#524. The other half is
eclipse-zenoh/zenoh-java#525, and this PR is that construction ported here,
together with the CI hygiene from eclipse-zenoh/zenoh-java#526.

**It supersedes #702.** Naming zenoh-flat-jni's own `1.9.0-SNAPSHOT`, as that PR
does, fixes the symptom and breaks two things: this repository's CI would wait on
that repository's CI, and that coordinate always holds the tip of *its* `main`
while this SDK compiles against the commit `Cargo.lock` pins. JNI being a binary
contract, the mismatch surfaces as `UnsatisfiedLinkError` at runtime rather than
as a build failure.

## The rule

**The publication publishes what it depends on.** On `main`, on every merge, it
builds `zenoh-flat-jni` from the pinned commit, uploads it as
`1.9.0-kotlin-SNAPSHOT`, then builds and uploads the SDK against that.

- **self-sufficient** — it uses that repository's *source at a commit we choose*,
  never an artifact its CI produced. If zenoh-flat-jni's CI were switched off
  entirely, this still works.
- **coherent** — the dependency our POM names is the code we compiled against.

| when | what happens |
| --- | --- |
| pull request, or push to a branch | build and test; nothing is published |
| merge to `main` | if the pinned commit moved, publish our `zenoh-flat-jni` copy; then publish the SDK snapshot; then consume it as an outsider |
| release workflow | unchanged; resolves a released `zenoh-flat-jni` from Maven Central |

## What changes

Second commit, `CI: publish the zenoh-flat-jni the snapshot was built against`:

- **`flat_jni_pin`** reads the pin from `Cargo.lock` and the commit stamp from
  all three published coordinates. Rebuilding is ten cross-compiled targets and
  about half an hour, and the pin moves roughly once a day, so it happens only
  when the published copy is not already that commit. Anything missing or
  unreadable reads as "not ours" and rebuilds — the safe direction.
  `ci/scripts/flat-jni-copy.bash --self-test` covers the parsers.
- **`publish_flat_jni_copy`** calls zenoh-flat-jni's own publication workflow
  rather than duplicating its six-target/four-ABI matrix, which is how the two
  would drift.
- **`-kotlin`** keeps our copy from overwriting the one zenoh-flat-jni publishes
  or zenoh-java's; the three can legitimately pin different commits at once. The
  name is fixed, so it is overwritten rather than accumulated.
- **`--refresh-dependencies`** on both SDK invocations. Gradle caches changing
  modules for 24 hours and `setup-gradle` restores that cache, so without it a
  run could upload copy B, compile against cached copy A, and publish a POM
  naming the coordinate that now resolves to B.
- **`ci/consumer-smoke-test`** — a separate Gradle build with no path, project or
  composite connection to this one. It resolves the published snapshot from the
  snapshot repository and takes a key expression through JNI. It is the only
  check that the whole chain works for someone who is not us. Written in Kotlin
  rather than Java, unlike zenoh-java's: `KeyExpr.tryFrom` returns a `Result`,
  and an inline value class is awkward to call across the Java boundary.
- **`concurrency`** with `cancel-in-progress: false`. The two uploads are not
  atomic, and cancelling a run mid-publication is exactly what leaves them naming
  different commits.
- **The release guard** in `bump-and-tag.bash` now checks the value
  `gradle.properties` ends up with rather than the workflow input, because `main`
  inherits a snapshot and omitting the input is how a release would reach one.
- **The pin moves to `6b5c04c`**, eclipse-zenoh/zenoh-flat-jni#37's merge commit.
  The earlier `e75529c` predates the `version-qualifier` inputs and the commit
  stamp this depends on, and that repository's preflight rejects it by design.
  Only that line of `Cargo.lock` moves — `cargo update -p` also re-resolves the
  `zenoh` git dependencies to their branch tip, which is the lockfile-sync bot's
  job, so they are pinned back.

First commit, `CI: pin third-party actions, fix the triggers, drop both
nightlies` — eclipse-zenoh/zenoh-java#526 ported:

- Every third-party action pinned to a commit, version in a trailing comment.
  Pinning picked up stale majors: `setup-java` v4 → v5.7.0, `setup-gradle`
  v4 → v5.0.2, `upload-artifact` v4 → v7.0.1, `actions-gh-pages` v3 → v4.1.0.
  `setup-gradle` stops at **v5**: v6 moved caching into a proprietary component
  under Gradle's own terms of use, which is not ours to accept for an Eclipse
  project.
- Triggers follow the main zenoh repository: `push` on `main` and release
  branches — a release is built from a branch `create-release-branch` makes, and
  CI never ran on it — and `pull_request` on `["**"]`, so a backport gets CI. Not
  `push` on `["**"]` as well: with `pull_request` on, that ran the whole matrix
  twice per branch.
- **Both nightlies go.** `ci.yml`'s would have rebuilt exactly what the last
  merge built, because `Cargo.lock` pins `zenoh-flat-jni` to a commit and Cargo
  re-resolves a git dependency only on `cargo update`. `release.yml`'s was worse
  than useless: a scheduled run passes no inputs, so every night it resolved the
  unreleased fallback in `gradle.properties` and died compiling.

## Verification

```console
$ bash ci/scripts/flat-jni-copy.bash --self-test
flat-jni-copy.bash self-test OK

$ bash ci/scripts/flat-jni-copy.bash
zenoh-flat-jni:1.9.0-kotlin-SNAPSHOT stamp is none, want 6b5c04c8…
commit=6b5c04c8… base=1.9.0 rebuild=true
```

Nothing is published under that coordinate yet, so the first merge to `main` is
the expensive one: the pin check finds no stamp, and the full ten-target matrix
runs before the SDK is published and consumed. It bootstraps itself — nothing
needs publishing by hand first.

Documentation is updated alongside: `CI.md` gains *What publishing uses*,
`PUBLISHING.md` gains *The snapshot publication* and *What it does not
guarantee* (including what the non-atomic pair of uploads does **not** promise),
and `README.md` says what the default `zenohFlatJniVersion` now means.
