### PR TITLE
CI: restore the GitHub release job, and make it runnable on its own

### DIFF
--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -26,8 +26,13 @@ on:
       # Empty here would fall back to the ref the dispatch was started from -
       # normally `main` - and a live run would then overwrite the published
       # documentation with the unreleased API. Recovery wants the released tag.
+      #
+      # Give it fully qualified as `refs/tags/<version>`: actions/checkout
+      # resolves a bare name to a remote branch before a tag, so a bare
+      # `1.10.0` would build a branch of that name if one existed, deploying
+      # movable content where the released tag was meant.
       branch:
-        description: Branch or tag to build the documentation from (use the released tag, e.g. 1.10.0)
+        description: Ref to build the documentation from - use refs/tags/<version> for a released version
         type: string
         required: true
 

--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -11,7 +11,21 @@ on:
         description: Target branch
         type: string
         required: false
+  # Dispatchable on its own so the documentation can be redeployed for a version
+  # that is already released - the same recovery path release-github.yml exists
+  # for. These inputs are not optional decoration: without them a dispatch got
+  # an empty `inputs`, so `live-run` was false and the deploy step below was
+  # skipped, which made a manual run build the site and silently throw it away.
   workflow_dispatch:
+    inputs:
+      live-run:
+        description: Live-run — actually deploy to gh-pages
+        type: boolean
+        required: false
+      branch:
+        description: Branch or tag to build the documentation from (e.g. 1.10.0)
+        type: string
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +34,11 @@ jobs:
   build_doc_and_deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
+    # Declared here rather than only on the caller, so a direct dispatch can
+    # push to gh-pages too. A called workflow gets the intersection of this and
+    # what the caller granted, and release.yml grants exactly this.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/publish-dokka.yml
+++ b/.github/workflows/publish-dokka.yml
@@ -22,10 +22,14 @@ on:
         description: Live-run — actually deploy to gh-pages
         type: boolean
         required: false
+      # Required, unlike the workflow_call side that release.yml always fills.
+      # Empty here would fall back to the ref the dispatch was started from -
+      # normally `main` - and a live run would then overwrite the published
+      # documentation with the unreleased API. Recovery wants the released tag.
       branch:
-        description: Branch or tag to build the documentation from (e.g. 1.10.0)
+        description: Branch or tag to build the documentation from (use the released tag, e.g. 1.10.0)
         type: string
-        required: false
+        required: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -85,9 +85,10 @@ jobs:
     steps:
       # Three checks, each answering a different question about the version the
       # operator typed. `version` is used verbatim as the tag name - bump-and-tag
-      # runs `git tag --force "$version"` - so the string names both. First,
-      # `--verify-tag` in `publish-crates-github` below: does a remote tag of
-      # that exact name exist at all? Then:
+      # runs `git tag --force "$version"` - so the string names both. First, the
+      # `--verify-tag` flag that `publish-crates-github` below passes to
+      # `gh release create`: does a remote tag of that exact name exist at all?
+      # Then:
       #
       # 1. version.txt at the tag == the version input. Note what this can and
       #    cannot prove. `bump-and-tag.bash` writes version.txt and creates the

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -131,17 +131,10 @@ jobs:
           fi
           echo "tag $VERSION carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
 
-      # Fails on anything but a 200. The two failures are different problems
-      # and get different messages - a 404 means the version is wrong or was
-      # never published, an unanswered request means Central is down - but
-      # neither is a reason to continue: proceeding unverified is exactly what
-      # this check exists to prevent, and it would do so precisely when
-      # verification was impossible.
-      #
-      # There is already an escape hatch for a deliberate release during an
-      # outage, and it is `check-maven` itself. Continuing on a network error
-      # would be a second one that fires automatically, overriding an operator
-      # who asked for the check with a warning in a green log that nobody reads.
+      # A 404 and an unanswered request are different problems - fix the
+      # version, versus try again later - so they get different messages, but
+      # both fail. Releasing during a Central outage is what `check-maven` off
+      # is for; the check should not decide that on its own.
       - name: Verify the version is on Maven Central
         if: ${{ inputs.check-maven }}
         env:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -107,16 +107,20 @@ jobs:
         with:
           ref: ${{ inputs.version }}
 
+      # `version` is operator-supplied, so it reaches the shell through the
+      # environment rather than being pasted into the script source.
       - name: Verify the tag is the release tag for this version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           tagged="$(tr -d '[:space:]' < version.txt)"
-          if [[ "$tagged" != "${{ inputs.version }}" ]]; then
-            echo "::error::tag '${{ inputs.version }}' has version.txt='$tagged'." \
+          if [[ "$tagged" != "$VERSION" ]]; then
+            echo "::error::tag '$VERSION' has version.txt='$tagged'." \
                  "This tag is not the release tag for that version." >&2
             exit 1
           fi
-          echo "tag ${{ inputs.version }} carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
+          echo "tag $VERSION carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
 
       # Only a 404 is evidence of absence. A timeout, a CDN 5xx or a DNS failure
       # means Central did not answer, which is not the same thing - and a
@@ -128,9 +132,11 @@ jobs:
       # to block a release because repo1.maven.org had a bad minute.
       - name: Verify the version is on Maven Central
         if: ${{ inputs.check-maven }}
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -uo pipefail
-          pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/${{ inputs.version }}/zenoh-kotlin-${{ inputs.version }}.pom"
+          pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/$VERSION/zenoh-kotlin-$VERSION.pom"
           code=000
           for attempt in 1 2 3 4 5; do
             # curl already writes 000 on a connection failure; don't append another.
@@ -144,9 +150,9 @@ jobs:
           done
 
           if [[ "$code" == 200 ]]; then
-            echo "zenoh-kotlin:${{ inputs.version }} resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
+            echo "zenoh-kotlin:$VERSION resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
           elif [[ "$code" == 404 ]]; then
-            echo "::error::zenoh-kotlin:${{ inputs.version }} is not on Maven Central (404 after 5 attempts)." \
+            echo "::error::zenoh-kotlin:$VERSION is not on Maven Central (404 after 5 attempts)." \
                  "Releasing it on GitHub would announce a version nobody can depend on." \
                  "If it was published minutes ago this may be propagation lag - wait, or re-run with check-maven off." >&2
             exit 1
@@ -172,13 +178,24 @@ jobs:
 
           args=(--repo "$REPO" --target "$BRANCH" --verify-tag --generate-notes)
 
-          previous="$(gh release list --repo "$REPO" --exclude-drafts --order desc \
-                        --limit 1 --json tagName --jq '.[0].tagName // empty')"
+          # The release *preceding this version*, not simply the newest one.
+          # They are the same during a release, but not for a recovery run: if
+          # 1.11.0 shipped while 1.10.0 was missing its release, starting from
+          # the newest would generate notes from 1.11.0 to 1.10.0 - backwards,
+          # and empty. Sorting VERSION into the list and taking its predecessor
+          # is right in both cases.
+          previous="$(
+            {
+              gh release list --repo "$REPO" --exclude-drafts --limit 100 \
+                 --json tagName --jq '.[].tagName'
+              printf '%s\n' "$VERSION"
+            } | sort -V -u | awk -v v="$VERSION" '$0 == v { print prev; exit } { prev = $0 }'
+          )"
           if [[ -n "$previous" ]]; then
             args+=(--notes-start-tag "$previous")
             echo "notes start after $previous"
           else
-            echo "no previous release; notes cover the full history"
+            echo "no earlier release; notes cover the full history"
           fi
 
           prerelease=false

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -83,18 +83,26 @@ jobs:
     name: Create the GitHub release
     runs-on: ubuntu-latest
     steps:
-      # These two checks catch a mistyped `version` reaching a real but wrong
-      # tag. `--verify-tag` below refuses a version with no tag at all, but a
-      # tag alone establishes little: `bump-and-tag.bash` tags rehearsals too,
-      # so `1.10.0-rc4` is a real tag that was never published to anything.
+      # Three checks, each answering a different question about the version the
+      # operator typed. `--verify-tag`, in the action below: does a tag exist at
+      # all? Then:
       #
-      # What they establish, precisely: this tag is *a* release tag for this
-      # version, and this version exists on Central. They do not tie the
-      # artifact to this commit - nothing published carries the commit it was
-      # built from (the POM has <scm> but no <tag>), so that cannot be checked
-      # here. A tag force-moved onto another commit with the same version.txt
-      # would still pass. Reaching that state means re-running a release whose
-      # version Central already accepted, which PUBLISHING.md says not to do.
+      # 1. version.txt at the tag == the version input. Note what this can and
+      #    cannot prove. `bump-and-tag.bash` writes version.txt and creates the
+      #    tag in the same run, so for any tag the release pipeline produced this
+      #    holds by construction - it is tautological for those. Its value is
+      #    rejecting tags the pipeline did *not* produce: one created by hand, or
+      #    one force-moved onto a commit belonging to a different version, where
+      #    the tag name and the file disagree.
+      # 2. check-maven: was this version ever published? This is the one that
+      #    rejects a rehearsal tag. Rehearsals are tagged too, and they are
+      #    self-consistent - version.txt at `1.10.0-rc4` reads `1.10.0-rc4` - so
+      #    they sail through check 1 and are caught only here.
+      #
+      # Neither ties the published artifact to this commit. Nothing published
+      # records the commit it was built from (the POM has <scm> but no <tag>),
+      # so that cannot be checked. A tag force-moved onto another commit that
+      # carries the same version.txt would pass both.
       # Fully qualified: given a bare name, actions/checkout looks for a remote
       # branch before a tag, so a branch named `1.10.0` alongside the tag would
       # have this validate version.txt from the branch while the action below

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 ZettaScale Technology
+# Copyright (c) 2026 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -84,8 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Three checks, each answering a different question about the version the
-      # operator typed. `--verify-tag`, in `publish-crates-github` below: does a tag exist at
-      # all? Then:
+      # operator typed. `version` is used verbatim as the tag name - bump-and-tag
+      # runs `git tag --force "$version"` - so the string names both. First,
+      # `--verify-tag` in `publish-crates-github` below: does a remote tag of
+      # that exact name exist at all? Then:
       #
       # 1. version.txt at the tag == the version input. Note what this can and
       #    cannot prove. `bump-and-tag.bash` writes version.txt and creates the

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -19,10 +19,12 @@ name: Release (GitHub)
 # own. Standalone is the point: the Maven publication is irreversible, so if a
 # release reaches Maven Central but the GitHub release is missing or wrong, you
 # must be able to create it without re-running the tag and publish jobs. A
-# GitHub release, unlike a Maven coordinate, can be edited or deleted
-# afterwards (`gh release edit` / `gh release delete`, which leaves the tag
-# alone), so re-running this is cheap - the one thing it does that cannot be
-# undone is notify watchers.
+# GitHub release, unlike a Maven coordinate, can be edited or deleted afterwards
+# (`gh release edit` / `gh release delete`, which leaves the tag alone), so a
+# mistake here is cheap to correct - though correcting it means editing or
+# deleting, since the action runs `gh release create`, which fails rather than
+# replacing an existing release. The one thing that cannot be undone is that
+# publishing notifies watchers.
 #
 # The job was removed in the zenoh-flat transition on the belief that
 # `eclipse-zenoh/ci/publish-crates-github` publishes crates and would fail
@@ -93,9 +95,15 @@ jobs:
       # here. A tag force-moved onto another commit with the same version.txt
       # would still pass. Reaching that state means re-running a release whose
       # version Central already accepted, which PUBLISHING.md says not to do.
+      # Fully qualified: given a bare name, actions/checkout looks for a remote
+      # branch before a tag, so a branch named `1.10.0` alongside the tag would
+      # have this validate version.txt from the branch while the action below
+      # publishes the tag - the guard failing open in exactly the ambiguous case
+      # it exists to catch. `refs/tags/` names the same thing `--verify-tag`
+      # resolves.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.version }}
+          ref: refs/tags/${{ inputs.version }}
 
       # `version` is operator-supplied, so it reaches the shell through the
       # environment rather than being pasted into the script source.
@@ -128,15 +136,19 @@ jobs:
           set -uo pipefail
           pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/$VERSION/zenoh-kotlin-$VERSION.pom"
           code=000
-          for attempt in 1 2 3 4 5; do
+          attempts=5
+          for attempt in $(seq "$attempts"); do
             # curl already writes 000 on a connection failure; don't append another.
             code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -I "$pom") || true
             [[ -n "$code" ]] || code=000
             case "$code" in
               200) break ;;
-              404) echo "attempt $attempt: not published yet (404)"; sleep $((attempt * 15)) ;;
-              *)   echo "attempt $attempt: Central did not answer (HTTP $code)"; sleep $((attempt * 15)) ;;
+              404) echo "attempt $attempt: not published yet (404)" ;;
+              *)   echo "attempt $attempt: Central did not answer (HTTP $code)" ;;
             esac
+            # No backoff after the last attempt - the verdict is already decided,
+            # and this is a recovery workflow that should not sit idle for it.
+            [[ "$attempt" -lt "$attempts" ]] && sleep $((attempt * 15))
           done
 
           if [[ "$code" == 200 ]]; then

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -50,7 +50,7 @@ on:
         type: string
         required: true
       check-maven:
-        description: "Best-effort check that the version is on Maven Central (404 fails; unreachable warns)"
+        description: Require the version to be on Maven Central before releasing
         type: boolean
         required: false
         # False from the pipeline, which only reaches this job when
@@ -73,7 +73,7 @@ on:
         type: string
         required: true
       check-maven:
-        description: "Best-effort check that the version is on Maven Central (404 fails; unreachable warns)"
+        description: Require the version to be on Maven Central before releasing
         type: boolean
         required: false
         default: true
@@ -131,49 +131,47 @@ jobs:
           fi
           echo "tag $VERSION carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
 
-      # Only a 404 is evidence of absence. A timeout, a CDN 5xx or a DNS failure
-      # means Central did not answer, which is not the same thing - and a
-      # release that just went out can take a while to appear, so an early 404
-      # can be lag rather than a typo. So: retry, fail closed on a *settled*
-      # 404, and on anything else say so and continue. The version.txt check
-      # above is the one that must hold; this catches the narrower case of a
-      # version that was tagged but never published, and it should not be able
-      # to block a release because repo1.maven.org had a bad minute.
+      # Fails on anything but a 200. The two failures are different problems
+      # and get different messages - a 404 means the version is wrong or was
+      # never published, an unanswered request means Central is down - but
+      # neither is a reason to continue: proceeding unverified is exactly what
+      # this check exists to prevent, and it would do so precisely when
+      # verification was impossible.
+      #
+      # There is already an escape hatch for a deliberate release during an
+      # outage, and it is `check-maven` itself. Continuing on a network error
+      # would be a second one that fires automatically, overriding an operator
+      # who asked for the check with a warning in a green log that nobody reads.
       - name: Verify the version is on Maven Central
         if: ${{ inputs.check-maven }}
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/$VERSION/zenoh-kotlin-$VERSION.pom"
-          code=000
-          attempts=5
-          for attempt in $(seq "$attempts"); do
-            # curl already writes 000 on a connection failure; don't append another.
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -I "$pom") || true
-            [[ -n "$code" ]] || code=000
-            case "$code" in
-              200) break ;;
-              404) echo "attempt $attempt: not published yet (404)" ;;
-              *)   echo "attempt $attempt: Central did not answer (HTTP $code)" ;;
-            esac
-            # No backoff after the last attempt - the verdict is already decided,
-            # and this is a recovery workflow that should not sit idle for it.
-            [[ "$attempt" -lt "$attempts" ]] && sleep $((attempt * 15))
-          done
 
-          if [[ "$code" == 200 ]]; then
-            echo "zenoh-kotlin:$VERSION resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
-          elif [[ "$code" == 404 ]]; then
-            echo "::error::zenoh-kotlin:$VERSION is not on Maven Central (404 after 5 attempts)." \
-                 "Releasing it on GitHub would announce a version nobody can depend on." \
-                 "If it was published minutes ago this may be propagation lag - wait, or re-run with check-maven off." >&2
-            exit 1
-          else
-            echo "::warning::Could not reach Maven Central (last status $code); proceeding unverified." >&2
-            echo "⚠️ Maven Central unreachable (HTTP $code) - the release was **not** verified against it." \
-              >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # curl already writes 000 on a connection failure; don't append another.
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -I "$pom") || true
+          [[ -n "$code" ]] || code=000
+
+          case "$code" in
+            200)
+              echo "zenoh-kotlin:$VERSION resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            404)
+              echo "::error::zenoh-kotlin:$VERSION is not on Maven Central." \
+                   "Releasing it on GitHub would announce a version nobody can depend on." \
+                   "Check the version, or wait if it was published minutes ago -" \
+                   "a release takes a while to propagate." >&2
+              exit 1
+              ;;
+            *)
+              echo "::error::Maven Central did not answer (HTTP $code), so $VERSION" \
+                   "could not be verified. Try again when it is reachable, or re-run" \
+                   "with check-maven off to release without this check." >&2
+              exit 1
+              ;;
+          esac
 
       # The org's shared release action, as zenoh-java and the rest of the Zenoh
       # repositories use it. It creates the release from the tag with generated

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -22,17 +22,17 @@ name: Release (GitHub)
 # GitHub release, unlike a Maven coordinate, can be edited or deleted afterwards
 # (`gh release edit` / `gh release delete`, which leaves the tag alone), so a
 # mistake here is cheap to correct - though correcting it means editing or
-# deleting, since the action runs `gh release create`, which fails rather than
-# replacing an existing release. The one thing that cannot be undone is that
-# publishing notifies watchers.
+# deleting, since `eclipse-zenoh/ci/publish-crates-github`, the shared action
+# this calls, runs `gh release create`, which fails rather than replacing an
+# existing release. The one thing that cannot be undone is that publishing
+# notifies watchers.
 #
 # The job was removed in the zenoh-flat transition on the belief that
-# `eclipse-zenoh/ci/publish-crates-github` publishes crates and would fail
-# without any in the repository. That was wrong: it needs no crate here, and
-# zenoh-java has been running it successfully throughout. So the action is back,
-# unchanged, and this repository stays on the same release path as the rest of
-# the org - see the note above the step for what that costs and why it is worth
-# it anyway.
+# `publish-crates-github` publishes crates and would fail without any in the
+# repository. That was wrong: it needs no crate here, and zenoh-java has been
+# running it successfully throughout. So the action is back, unchanged, and this
+# repository stays on the same release path as the rest of the org - see the
+# note above the step for what that costs and why it is worth it anyway.
 
 on:
   workflow_call:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Three checks, each answering a different question about the version the
-      # operator typed. `--verify-tag`, in the action below: does a tag exist at
+      # operator typed. `--verify-tag`, in `publish-crates-github` below: does a tag exist at
       # all? Then:
       #
       # 1. version.txt at the tag == the version input. Note what this can and
@@ -105,8 +105,8 @@ jobs:
       # carries the same version.txt would pass both.
       # Fully qualified: given a bare name, actions/checkout looks for a remote
       # branch before a tag, so a branch named `1.10.0` alongside the tag would
-      # have this validate version.txt from the branch while the action below
-      # publishes the tag - the guard failing open in exactly the ambiguous case
+      # have this validate version.txt from the branch while
+      # `publish-crates-github` below publishes the tag - the guard failing open in exactly the ambiguous case
       # it exists to catch. `refs/tags/` names the same thing `--verify-tag`
       # resolves.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -92,10 +92,11 @@ jobs:
     #   Is the tag self-consistent?     version.txt at the tag == version input
     #   Was the version published?      check-maven
     #
-    # The second is tautological for any tag the pipeline made, since
-    # bump-and-tag writes version.txt and creates the tag in one run. Its value
-    # is rejecting tags the pipeline did not make: created by hand, or
-    # force-moved onto a commit belonging to another version.
+    # The second is narrow. bump-and-tag writes version.txt and creates the tag
+    # in one run, so every tag the pipeline made passes it. What it rejects is a
+    # tag pointing at a commit whose version.txt names a different version - one
+    # moved onto another version's commit, or created there. A tag made by hand
+    # on the right commit passes, so this does not establish who made the tag.
     #
     # The third is what rejects a rehearsal tag. Rehearsals are tagged too and
     # are self-consistent - version.txt at `1.10.0-rc4` reads `1.10.0-rc4` - so
@@ -104,6 +105,29 @@ jobs:
     # None of the three ties the published artifact to this commit: nothing
     # published records the commit it was built from.
     steps:
+      # `version` and `branch` reach publish-crates-github, which builds a shell
+      # command string from them and runs it with the bot token in the
+      # environment (eclipse-zenoh/ci#470). Until that is fixed upstream, both
+      # are constrained here to characters that cannot become shell syntax.
+      # The value is never echoed back: an invalid one is attacker-controlled
+      # and would itself be interpreted as a workflow command.
+      - name: Validate the inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          check() {
+            if [[ ! "$2" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+              echo "::error::input '$1' is not a plain ref name." \
+                   "Allowed: letters, digits, and . _ - / after a leading" \
+                   "letter or digit." >&2
+              exit 1
+            fi
+          }
+          check version "$VERSION"
+          check branch "$BRANCH"
+
       # Fully qualified, because actions/checkout resolves a bare name to a
       # remote branch before a tag. A branch named `1.10.0` beside the tag would
       # have this step read version.txt from the branch while
@@ -122,8 +146,8 @@ jobs:
           set -euo pipefail
           tagged="$(tr -d '[:space:]' < version.txt)"
           if [[ "$tagged" != "$VERSION" ]]; then
-            echo "::error::tag '$VERSION' has version.txt='$tagged'." \
-                 "This tag is not the release tag for that version." >&2
+            echo "::error::tag '$VERSION' points at a commit whose version.txt" \
+                 "reads '$tagged'. The tag and the commit name different versions." >&2
             exit 1
           fi
           echo "tag $VERSION carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,22 +25,12 @@ name: Release (GitHub)
 # undone is notify watchers.
 #
 # The job was removed in the zenoh-flat transition on the belief that
-# `eclipse-zenoh/ci/publish-crates-github` publishes Rust crates and would fail
-# without any in the repository. That was wrong - it needs no crate here, and
-# zenoh-java runs it successfully today - but the action is still not the right
-# thing to call from a recovery path. It reaches
-# `build-crates-debian.ts` for one artifact regex, and that module runs
-# `await TOML.init()` at import, so every invocation first does
-# `cargo +stable install toml-cli2@0.3.2 --force`: a Rust toolchain, a
-# crates.io fetch and about 40s of compiling before it runs `gh`. This
-# workflow's whole purpose is to still work when the release pipeline did not,
-# so it should not depend on crates.io being up.
-#
-# What the action does that we need is two `gh` calls, reproduced below. What it
-# does that we do not need is upload `*-standalone.zip` / `*-debian.zip` build
-# artifacts, of which this repository produces none. Keeping the two calls
-# inline costs a few lines and removes a whole class of unrelated failure.
-# See eclipse-zenoh/ci - the eager TOML init is worth removing upstream too.
+# `eclipse-zenoh/ci/publish-crates-github` publishes crates and would fail
+# without any in the repository. That was wrong: it needs no crate here, and
+# zenoh-java has been running it successfully throughout. So the action is back,
+# unchanged, and this repository stays on the same release path as the rest of
+# the org - see the note above the step for what that costs and why it is worth
+# it anyway.
 
 on:
   workflow_call:
@@ -162,57 +152,30 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # Same two calls eclipse-zenoh/ci/publish-crates-github makes, minus the
-      # Cargo dependency it drags in - see the note at the top of this file.
-      # Notes start at the newest existing release so they cover only what is
-      # new in this one. Pre-release detection matches the action's rule: a `-`
-      # anywhere but the front, or four dot-separated components.
-      - name: Create the GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}
-          VERSION: ${{ inputs.version }}
-          BRANCH: ${{ inputs.branch }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          args=(--repo "$REPO" --target "$BRANCH" --verify-tag --generate-notes)
-
-          # The release *preceding this version*, not simply the newest one.
-          # They are the same during a release, but not for a recovery run: if
-          # 1.11.0 shipped while 1.10.0 was missing its release, starting from
-          # the newest would generate notes from 1.11.0 to 1.10.0 - backwards,
-          # and empty. Sorting VERSION into the list and taking its predecessor
-          # is right in both cases.
-          previous="$(
-            {
-              gh release list --repo "$REPO" --exclude-drafts --limit 100 \
-                 --json tagName --jq '.[].tagName'
-              printf '%s\n' "$VERSION"
-            } | sort -V -u | awk -v v="$VERSION" '$0 == v { print prev; exit } { prev = $0 }'
-          )"
-          if [[ -n "$previous" ]]; then
-            args+=(--notes-start-tag "$previous")
-            echo "notes start after $previous"
-          else
-            echo "no earlier release; notes cover the full history"
-          fi
-
-          prerelease=false
-          case "$VERSION" in ?*-*) prerelease=true ;; esac
-          if [[ "$(printf '%s' "$VERSION" | awk -F. '{print NF}')" == 4 ]]; then
-            prerelease=true
-          fi
-          if [[ "$prerelease" == true ]]; then
-            args+=(--prerelease)
-            echo "$VERSION is a pre-release"
-          fi
-
-          if [[ "${{ inputs.live-run || false }}" != "true" ]]; then
-            echo "dry run; would have run: gh release create $VERSION ${args[*]}" \
-              >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          gh release create "$VERSION" "${args[@]}"
-          echo "released https://github.com/$REPO/releases/tag/$VERSION" >> "$GITHUB_STEP_SUMMARY"
+      # The org's shared release action, as zenoh-java and the rest of the Zenoh
+      # repositories use it. It creates the release from the tag with generated
+      # notes, then attaches any `*-standalone.zip` / `*-debian.zip` build
+      # archives - of which this repository produces none, so that half is inert
+      # here and every release it has ever made carried notes only.
+      #
+      # Two known upstream defects, tracked in eclipse-zenoh/ci, neither of which
+      # affects a normal release:
+      #
+      #  - it installs `toml-cli2` from crates.io before running `gh`, because
+      #    `publish-crates-github.ts` imports `build-crates-debian.ts` for one
+      #    filename pattern and that module runs `await TOML.init()` at import.
+      #    Roughly 40s and a crates.io dependency this workflow does not need.
+      #  - it bounds the generated notes with the *newest* existing release
+      #    rather than the one preceding this version. Identical during a
+      #    release; wrong only when recovering a version after a newer one has
+      #    already shipped, which then produces empty notes.
+      #
+      # Reusing the shared action is worth both: fixes belong upstream where
+      # every Zenoh repository gets them, not worked around in one repo.
+      - uses: eclipse-zenoh/ci/publish-crates-github@main
+        with:
+          repo: ${{ github.repository }}
+          live-run: ${{ inputs.live-run || false }}
+          version: ${{ inputs.version }}
+          branch: ${{ inputs.branch }}
+          github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -82,36 +82,33 @@ jobs:
   publish-github:
     name: Create the GitHub release
     runs-on: ubuntu-latest
+    # Three questions about the version the operator typed, answered in order.
+    # `version` is used verbatim as the tag name - bump-and-tag runs
+    # `git tag --force "$version"` - so the one string names both.
+    #
+    #   Does a tag of that name exist?  `--verify-tag`, which
+    #                                   publish-crates-github passes to
+    #                                   `gh release create`
+    #   Is the tag self-consistent?     version.txt at the tag == version input
+    #   Was the version published?      check-maven
+    #
+    # The second is tautological for any tag the pipeline made, since
+    # bump-and-tag writes version.txt and creates the tag in one run. Its value
+    # is rejecting tags the pipeline did not make: created by hand, or
+    # force-moved onto a commit belonging to another version.
+    #
+    # The third is what rejects a rehearsal tag. Rehearsals are tagged too and
+    # are self-consistent - version.txt at `1.10.0-rc4` reads `1.10.0-rc4` - so
+    # a rehearsal tag passes the second check and is caught only here.
+    #
+    # None of the three ties the published artifact to this commit: nothing
+    # published records the commit it was built from.
     steps:
-      # Three checks, each answering a different question about the version the
-      # operator typed. `version` is used verbatim as the tag name - bump-and-tag
-      # runs `git tag --force "$version"` - so the string names both. First, the
-      # `--verify-tag` flag that `publish-crates-github` below passes to
-      # `gh release create`: does a remote tag of that exact name exist at all?
-      # Then:
-      #
-      # 1. version.txt at the tag == the version input. Note what this can and
-      #    cannot prove. `bump-and-tag.bash` writes version.txt and creates the
-      #    tag in the same run, so for any tag the release pipeline produced this
-      #    holds by construction - it is tautological for those. Its value is
-      #    rejecting tags the pipeline did *not* produce: one created by hand, or
-      #    one force-moved onto a commit belonging to a different version, where
-      #    the tag name and the file disagree.
-      # 2. check-maven: was this version ever published? This is the one that
-      #    rejects a rehearsal tag. Rehearsals are tagged too, and they are
-      #    self-consistent - version.txt at `1.10.0-rc4` reads `1.10.0-rc4` - so
-      #    they sail through check 1 and are caught only here.
-      #
-      # Neither ties the published artifact to this commit. Nothing published
-      # records the commit it was built from (the POM has <scm> but no <tag>),
-      # so that cannot be checked. A tag force-moved onto another commit that
-      # carries the same version.txt would pass both.
-      # Fully qualified: given a bare name, actions/checkout looks for a remote
-      # branch before a tag, so a branch named `1.10.0` alongside the tag would
-      # have this validate version.txt from the branch while
-      # `publish-crates-github` below publishes the tag - the guard failing open in exactly the ambiguous case
-      # it exists to catch. `refs/tags/` names the same thing `--verify-tag`
-      # resolves.
+      # Fully qualified, because actions/checkout resolves a bare name to a
+      # remote branch before a tag. A branch named `1.10.0` beside the tag would
+      # have this step read version.txt from the branch while
+      # publish-crates-github publishes the tag - the check failing open in the
+      # one case it exists to catch.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ inputs.version }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -24,12 +24,23 @@ name: Release (GitHub)
 # alone), so re-running this is cheap - the one thing it does that cannot be
 # undone is notify watchers.
 #
-# The underlying action only shells out to `gh release create --verify-tag
-# --generate-notes` and then uploads any `*-standalone.zip` / `*-debian.zip`
-# workflow artifacts. This repository builds no Rust crates, so that upload
-# loop finds nothing and the release carries generated notes only. It was
-# removed in the zenoh-flat transition on the belief that it published crates
-# and would fail without them; it does not, and zenoh-java never dropped it.
+# The job was removed in the zenoh-flat transition on the belief that
+# `eclipse-zenoh/ci/publish-crates-github` publishes Rust crates and would fail
+# without any in the repository. That was wrong - it needs no crate here, and
+# zenoh-java runs it successfully today - but the action is still not the right
+# thing to call from a recovery path. It reaches
+# `build-crates-debian.ts` for one artifact regex, and that module runs
+# `await TOML.init()` at import, so every invocation first does
+# `cargo +stable install toml-cli2@0.3.2 --force`: a Rust toolchain, a
+# crates.io fetch and about 40s of compiling before it runs `gh`. This
+# workflow's whole purpose is to still work when the release pipeline did not,
+# so it should not depend on crates.io being up.
+#
+# What the action does that we need is two `gh` calls, reproduced below. What it
+# does that we do not need is upload `*-standalone.zip` / `*-debian.zip` build
+# artifacts, of which this repository produces none. Keeping the two calls
+# inline costs a few lines and removes a whole class of unrelated failure.
+# See eclipse-zenoh/ci - the eager TOML init is worth removing upstream too.
 
 on:
   workflow_call:
@@ -47,10 +58,11 @@ on:
         type: string
         required: true
       check-maven:
-        description: Require the version to be on Maven Central first
+        description: "Best-effort check that the version is on Maven Central (404 fails; unreachable warns)"
         type: boolean
         required: false
-        # False from the pipeline: the publish job that just ran is the
+        # False from the pipeline, which only reaches this job when
+        # maven_publish was on - so the publish job that just ran is the
         # evidence, and a freshly released coordinate takes a while to appear on
         # repo1.maven.org, so checking here would fail every live release.
         default: false
@@ -69,7 +81,7 @@ on:
         type: string
         required: true
       check-maven:
-        description: Require the version to be on Maven Central first
+        description: "Best-effort check that the version is on Maven Central (404 fails; unreachable warns)"
         type: boolean
         required: false
         default: true
@@ -79,11 +91,18 @@ jobs:
     name: Create the GitHub release
     runs-on: ubuntu-latest
     steps:
-      # The GitHub release must describe the same commit Maven Central got.
-      # `--verify-tag` below already refuses a version with no tag, but tags
-      # alone do not establish that: `bump-and-tag.bash` tags rehearsals too, so
-      # `1.10.0-rc4` is a tag that was never published to anything. Both checks
-      # here are about a mistyped `version` reaching a real but wrong tag.
+      # These two checks catch a mistyped `version` reaching a real but wrong
+      # tag. `--verify-tag` below refuses a version with no tag at all, but a
+      # tag alone establishes little: `bump-and-tag.bash` tags rehearsals too,
+      # so `1.10.0-rc4` is a real tag that was never published to anything.
+      #
+      # What they establish, precisely: this tag is *a* release tag for this
+      # version, and this version exists on Central. They do not tie the
+      # artifact to this commit - nothing published carries the commit it was
+      # built from (the POM has <scm> but no <tag>), so that cannot be checked
+      # here. A tag force-moved onto another commit with the same version.txt
+      # would still pass. Reaching that state means re-running a release whose
+      # version Central already accepted, which PUBLISHING.md says not to do.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.version }}
@@ -137,10 +156,46 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - uses: eclipse-zenoh/ci/publish-crates-github@main
-        with:
-          repo: ${{ github.repository }}
-          live-run: ${{ inputs.live-run || false }}
-          version: ${{ inputs.version }}
-          branch: ${{ inputs.branch }}
-          github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+      # Same two calls eclipse-zenoh/ci/publish-crates-github makes, minus the
+      # Cargo dependency it drags in - see the note at the top of this file.
+      # Notes start at the newest existing release so they cover only what is
+      # new in this one. Pre-release detection matches the action's rule: a `-`
+      # anywhere but the front, or four dot-separated components.
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          args=(--repo "$REPO" --target "$BRANCH" --verify-tag --generate-notes)
+
+          previous="$(gh release list --repo "$REPO" --exclude-drafts --order desc \
+                        --limit 1 --json tagName --jq '.[0].tagName // empty')"
+          if [[ -n "$previous" ]]; then
+            args+=(--notes-start-tag "$previous")
+            echo "notes start after $previous"
+          else
+            echo "no previous release; notes cover the full history"
+          fi
+
+          prerelease=false
+          case "$VERSION" in ?*-*) prerelease=true ;; esac
+          if [[ "$(printf '%s' "$VERSION" | awk -F. '{print NF}')" == 4 ]]; then
+            prerelease=true
+          fi
+          if [[ "$prerelease" == true ]]; then
+            args+=(--prerelease)
+            echo "$VERSION is a pre-release"
+          fi
+
+          if [[ "${{ inputs.live-run || false }}" != "true" ]]; then
+            echo "dry run; would have run: gh release create $VERSION ${args[*]}" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh release create "$VERSION" "${args[@]}"
+          echo "released https://github.com/$REPO/releases/tag/$VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -178,20 +178,10 @@ jobs:
       # archives - of which this repository produces none, so that half is inert
       # here and every release it has ever made carried notes only.
       #
-      # Two known upstream defects, tracked in eclipse-zenoh/ci, neither of which
-      # affects a normal release:
-      #
-      #  - it installs `toml-cli2` from crates.io before running `gh`, because
-      #    `publish-crates-github.ts` imports `build-crates-debian.ts` for one
-      #    filename pattern and that module runs `await TOML.init()` at import.
-      #    Roughly 40s and a crates.io dependency this workflow does not need.
-      #  - it bounds the generated notes with the *newest* existing release
-      #    rather than the one preceding this version. Identical during a
-      #    release; wrong only when recovering a version after a newer one has
-      #    already shipped, which then produces empty notes.
-      #
-      # Reusing the shared action is worth both: fixes belong upstream where
-      # every Zenoh repository gets them, not worked around in one repo.
+      # Two known upstream defects are tracked in eclipse-zenoh/ci#470; neither
+      # affects a normal release. They are deliberately not worked around here:
+      # a fix upstream reaches every Zenoh repository, one here reaches this
+      # repository only.
       - uses: eclipse-zenoh/ci/publish-crates-github@main
         with:
           repo: ${{ github.repository }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -99,17 +99,43 @@ jobs:
           fi
           echo "tag ${{ inputs.version }} carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
 
+      # Only a 404 is evidence of absence. A timeout, a CDN 5xx or a DNS failure
+      # means Central did not answer, which is not the same thing - and a
+      # release that just went out can take a while to appear, so an early 404
+      # can be lag rather than a typo. So: retry, fail closed on a *settled*
+      # 404, and on anything else say so and continue. The version.txt check
+      # above is the one that must hold; this catches the narrower case of a
+      # version that was tagged but never published, and it should not be able
+      # to block a release because repo1.maven.org had a bad minute.
       - name: Verify the version is on Maven Central
         if: ${{ inputs.check-maven }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/${{ inputs.version }}/zenoh-kotlin-${{ inputs.version }}.pom"
-          if ! curl -sfI "$pom" > /dev/null; then
-            echo "::error::zenoh-kotlin:${{ inputs.version }} is not on Maven Central." \
-                 "Releasing it on GitHub would announce a version nobody can depend on." >&2
+          code=000
+          for attempt in 1 2 3 4 5; do
+            # curl already writes 000 on a connection failure; don't append another.
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -I "$pom") || true
+            [[ -n "$code" ]] || code=000
+            case "$code" in
+              200) break ;;
+              404) echo "attempt $attempt: not published yet (404)"; sleep $((attempt * 15)) ;;
+              *)   echo "attempt $attempt: Central did not answer (HTTP $code)"; sleep $((attempt * 15)) ;;
+            esac
+          done
+
+          if [[ "$code" == 200 ]]; then
+            echo "zenoh-kotlin:${{ inputs.version }} resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$code" == 404 ]]; then
+            echo "::error::zenoh-kotlin:${{ inputs.version }} is not on Maven Central (404 after 5 attempts)." \
+                 "Releasing it on GitHub would announce a version nobody can depend on." \
+                 "If it was published minutes ago this may be propagation lag - wait, or re-run with check-maven off." >&2
             exit 1
+          else
+            echo "::warning::Could not reach Maven Central (last status $code); proceeding unverified." >&2
+            echo "⚠️ Maven Central unreachable (HTTP $code) - the release was **not** verified against it." \
+              >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "zenoh-kotlin:${{ inputs.version }} resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
 
       - uses: eclipse-zenoh/ci/publish-crates-github@main
         with:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,120 @@
+#
+# Copyright (c) 2022 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+name: Release (GitHub)
+
+# Creates the GitHub release for an already-tagged version.
+#
+# This is both a step of `release.yml` and a workflow you can dispatch on its
+# own. Standalone is the point: the Maven publication is irreversible, so if a
+# release reaches Maven Central but the GitHub release is missing or wrong, you
+# must be able to create it without re-running the tag and publish jobs. A
+# GitHub release, unlike a Maven coordinate, can be edited or deleted
+# afterwards (`gh release edit` / `gh release delete`, which leaves the tag
+# alone), so re-running this is cheap - the one thing it does that cannot be
+# undone is notify watchers.
+#
+# The underlying action only shells out to `gh release create --verify-tag
+# --generate-notes` and then uploads any `*-standalone.zip` / `*-debian.zip`
+# workflow artifacts. This repository builds no Rust crates, so that upload
+# loop finds nothing and the release carries generated notes only. It was
+# removed in the zenoh-flat transition on the belief that it published crates
+# and would fail without them; it does not, and zenoh-java never dropped it.
+
+on:
+  workflow_call:
+    inputs:
+      live-run:
+        description: Live-run
+        type: boolean
+        required: true
+      version:
+        description: Release number, which must already exist as a tag
+        type: string
+        required: true
+      branch:
+        description: Release branch the tag lives on
+        type: string
+        required: true
+      check-maven:
+        description: Require the version to be on Maven Central first
+        type: boolean
+        required: false
+        # False from the pipeline: the publish job that just ran is the
+        # evidence, and a freshly released coordinate takes a while to appear on
+        # repo1.maven.org, so checking here would fail every live release.
+        default: false
+  workflow_dispatch:
+    inputs:
+      live-run:
+        description: Live-run
+        type: boolean
+        required: false
+      version:
+        description: Release number, which must already exist as a tag (e.g. 1.10.0)
+        type: string
+        required: true
+      branch:
+        description: Release branch the tag lives on (e.g. release/1.10.0)
+        type: string
+        required: true
+      check-maven:
+        description: Require the version to be on Maven Central first
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  publish-github:
+    name: Create the GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      # The GitHub release must describe the same commit Maven Central got.
+      # `--verify-tag` below already refuses a version with no tag, but tags
+      # alone do not establish that: `bump-and-tag.bash` tags rehearsals too, so
+      # `1.10.0-rc4` is a tag that was never published to anything. Both checks
+      # here are about a mistyped `version` reaching a real but wrong tag.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Verify the tag is the release tag for this version
+        run: |
+          set -euo pipefail
+          tagged="$(tr -d '[:space:]' < version.txt)"
+          if [[ "$tagged" != "${{ inputs.version }}" ]]; then
+            echo "::error::tag '${{ inputs.version }}' has version.txt='$tagged'." \
+                 "This tag is not the release tag for that version." >&2
+            exit 1
+          fi
+          echo "tag ${{ inputs.version }} carries version.txt=$tagged" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify the version is on Maven Central
+        if: ${{ inputs.check-maven }}
+        run: |
+          set -euo pipefail
+          pom="https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/${{ inputs.version }}/zenoh-kotlin-${{ inputs.version }}.pom"
+          if ! curl -sfI "$pom" > /dev/null; then
+            echo "::error::zenoh-kotlin:${{ inputs.version }} is not on Maven Central." \
+                 "Releasing it on GitHub would announce a version nobody can depend on." >&2
+            exit 1
+          fi
+          echo "zenoh-kotlin:${{ inputs.version }} resolves from Maven Central" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: eclipse-zenoh/ci/publish-crates-github@main
+        with:
+          repo: ${{ github.repository }}
+          live-run: ${{ inputs.live-run || false }}
+          version: ${{ inputs.version }}
+          branch: ${{ inputs.branch }}
+          github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,18 @@ jobs:
       packages: write
     secrets: inherit
 
+  # `live-run` is ANDed with `maven_publish` rather than passed through. With
+  # uploads off the publish job still succeeds, so a live run would otherwise
+  # deploy the documentation of a version that exists nowhere but this
+  # repository, over the docs of the version people are actually using. The job
+  # still runs and still builds the site - that is the part worth exercising -
+  # it just does not publish it.
   publish-dokka:
     name: Publish documentation
     needs: [tag, publish]
     uses: ./.github/workflows/publish-dokka.yml
     with:
-      live-run: ${{ inputs.live-run || false }}
+      live-run: ${{ (inputs.live-run || false) && !contains(inputs.maven_publish, 'false') }}
       branch: ${{ needs.tag.outputs.branch }}
     # peaceiris/actions-gh-pages pushes the generated site to the gh-pages
     # branch, which the default read-only token cannot do.
@@ -113,9 +119,15 @@ jobs:
   # Gated on `maven_publish` as well as `github_release`. The publish job
   # succeeds either way - with `maven_publish` off it only assembles locally -
   # so without this a live run with uploads disabled would announce a release
-  # for a coordinate that was never published. That combination is a rehearsal,
-  # not a release; a genuine GitHub-only release is the standalone workflow,
-  # which verifies against Central rather than assuming an upload happened.
+  # for a coordinate that was never published.
+  #
+  # `live-run: true` with `maven_publish: false` is not a rehearsal: it cuts the
+  # real release branch, force-pushes the real tag, and but for these two gates
+  # would deploy the real docs and announce a real release. It is a live release
+  # with the upload switched off - useful for exercising the tag and build path,
+  # and precisely the state in which nothing outward-facing should happen. A
+  # genuine GitHub-only release is the standalone workflow, which verifies
+  # against Central rather than assuming an upload happened.
   publish-github:
     name: Create the GitHub release
     needs: [tag, publish]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ on:
         description: Publish the package to Maven Central
         required: false
         default: true
+      github_release:
+        type: boolean
+        description: Create the GitHub release
+        required: false
+        default: true
 
 jobs:
   tag:
@@ -98,3 +103,19 @@ jobs:
     # branch, which the default read-only token cannot do.
     permissions:
       contents: write
+
+  # Last, because a GitHub release is the announcement: it notifies watchers,
+  # and it should not fire for a version whose artifacts failed to publish.
+  # `release-github.yml` is also dispatchable on its own, which is how you
+  # recover a release that was published to Maven Central without one - see the
+  # comment at the top of that file.
+  publish-github:
+    name: Create the GitHub release
+    needs: [tag, publish]
+    if: ${{ !contains(inputs.github_release, 'false') }}
+    uses: ./.github/workflows/release-github.yml
+    with:
+      live-run: ${{ inputs.live-run || false }}
+      version: ${{ needs.tag.outputs.version }}
+      branch: ${{ needs.tag.outputs.branch }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,28 @@ jobs:
       version: ${{ steps.create-release-branch.outputs.version }}
       branch: ${{ steps.create-release-branch.outputs.branch }}
     steps:
+      # First, so nothing is created when the combination is rejected.
+      #
+      # `maven_publish` suppresses the upload; it does not make a run a
+      # rehearsal. Combined with `live-run` it would cut the real release
+      # branch, force-push the real tag, and then upload, deploy and announce
+      # nothing - leaving a tag for a version that exists nowhere, which is the
+      # state a failed release leaves and that PUBLISHING.md says to avoid.
+      #
+      # Nothing is lost by refusing it. Rehearsing without uploading is
+      # `live-run` off, which does the same build and leaves a prunable
+      # dry-run branch; a GitHub-only release is the Release (GitHub) workflow,
+      # which verifies against Central instead of assuming an upload happened.
+      - name: Reject a live run with publishing disabled
+        if: ${{ (inputs.live-run || false) && contains(inputs.maven_publish, 'false') }}
+        run: |
+          echo "::error::live-run with maven_publish disabled would force-push the real tag" \
+               "and publish nothing, leaving a tag for a version that exists nowhere." \
+               "To rehearse without uploading, uncheck live-run." \
+               "To create a GitHub release for a version already on Central, run" \
+               "the 'Release (GitHub)' workflow." >&2
+          exit 1
+
       - id: create-release-branch
         uses: eclipse-zenoh/ci/create-release-branch@main
         with:
@@ -98,6 +120,10 @@ jobs:
   # repository, over the docs of the version people are actually using. The job
   # still runs and still builds the site - that is the part worth exercising -
   # it just does not publish it.
+  #
+  # The tag job now rejects that combination outright, so this is defence in
+  # depth: the invariant "nothing outward-facing without an upload" is stated
+  # where it applies, not only where it is currently enforced.
   publish-dokka:
     name: Publish documentation
     needs: [tag, publish]
@@ -121,13 +147,11 @@ jobs:
   # so without this a live run with uploads disabled would announce a release
   # for a coordinate that was never published.
   #
-  # `live-run: true` with `maven_publish: false` is not a rehearsal: it cuts the
-  # real release branch, force-pushes the real tag, and but for these two gates
-  # would deploy the real docs and announce a real release. It is a live release
-  # with the upload switched off - useful for exercising the tag and build path,
-  # and precisely the state in which nothing outward-facing should happen. A
-  # genuine GitHub-only release is the standalone workflow, which verifies
-  # against Central rather than assuming an upload happened.
+  # The tag job rejects `live-run` with `maven_publish` off before anything is
+  # created, so the `maven_publish` half of this condition is defence in depth;
+  # the `github_release` half is what actually varies. A genuine GitHub-only
+  # release is the standalone workflow, which verifies against Central rather
+  # than assuming an upload happened.
   publish-github:
     name: Create the GitHub release
     needs: [tag, publish]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,17 @@ jobs:
   # `release-github.yml` is also dispatchable on its own, which is how you
   # recover a release that was published to Maven Central without one - see the
   # comment at the top of that file.
+  #
+  # Gated on `maven_publish` as well as `github_release`. The publish job
+  # succeeds either way - with `maven_publish` off it only assembles locally -
+  # so without this a live run with uploads disabled would announce a release
+  # for a coordinate that was never published. That combination is a rehearsal,
+  # not a release; a genuine GitHub-only release is the standalone workflow,
+  # which verifies against Central rather than assuming an upload happened.
   publish-github:
     name: Create the GitHub release
     needs: [tag, publish]
-    if: ${{ !contains(inputs.github_release, 'false') }}
+    if: ${{ !contains(inputs.github_release, 'false') && !contains(inputs.maven_publish, 'false') }}
     uses: ./.github/workflows/release-github.yml
     with:
       live-run: ${{ inputs.live-run || false }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -193,11 +193,18 @@ builds and publishes.
 | `maven_publish` | checked — or uncheck for the very first run |
 | `github_release` | either — a rehearsal is not a live run, so no release is created regardless |
 
-Unchecking `maven_publish` also skips the GitHub release, whatever
-`github_release` says: with no upload there is nothing for a release to
-announce. To create one for a version already on Central, use
-[Release (GitHub)](#creating-a-github-release-on-its-own), which verifies
-instead of assuming.
+Unchecking `maven_publish` suppresses **everything outward-facing**, even on a
+live run: no GitHub release, whatever `github_release` says, and no
+documentation deploy. With no upload there is nothing to announce, and nothing
+whose documentation should replace the published site. Both jobs still run and
+still build, so the rehearsal value is intact — only the publishing stops.
+
+Note that `live-run` checked with `maven_publish` unchecked is *not* a
+rehearsal: it cuts the real release branch and force-pushes the real tag. It is
+a live release with the upload switched off. To publish a GitHub release or the
+documentation for a version already on Central, use the standalone workflows
+under [If a step after Maven Central
+fails](#if-a-step-after-maven-central-fails), which verify rather than assume.
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
 `live-run` publishes `<version>-SNAPSHOT` to the **mutable** snapshot repository

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,6 +22,7 @@ which covers them once for the whole stack.
   - [Before the first run](#before-the-first-run)
   - [Rehearsal (dry run)](#rehearsal-dry-run)
   - [The real release](#the-real-release)
+  - [Creating a GitHub release on its own](#creating-a-github-release-on-its-own)
   - [After a release](#after-a-release)
 - [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released)
   - [Rehearsing the release workflow with a snapshot](#rehearsing-the-release-workflow-with-a-snapshot)
@@ -188,6 +189,7 @@ builds and publishes.
 | `version` | a fresh provisional number, not one already used |
 | `zenoh-flat-jni-version` | a version that exists — today a snapshot, see [below](#rehearsing-the-release-workflow-with-a-snapshot). Empty falls back to `gradle.properties`, which names our own `1.9.0-kotlin-SNAPSHOT` copy: fine for a rehearsal, refused for a live run |
 | `maven_publish` | checked — or uncheck for the very first run |
+| `github_release` | either — a rehearsal is not a live run, so no release is created regardless |
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
 `live-run` publishes `<version>-SNAPSHOT` to the **mutable** snapshot repository
@@ -207,10 +209,45 @@ never give a rehearsal the number you intend to release.
 | `version` | the release number |
 | `zenoh-flat-jni-version` | the zenoh-flat-jni release to build against — **must already be on Central** |
 | `maven_publish` | checked |
+| `github_release` | checked |
 
 Supplying `zenoh-flat-jni-version` rewrites `zenohFlatJniVersion` in
 `gradle.properties` and commits it, so the published POM records exactly which
 binding release the SDK was built against.
+
+### Creating a GitHub release on its own
+
+The **Release (GitHub)** workflow creates the GitHub release for a version that
+is already tagged, without re-running the tag or publish jobs. Use it when a
+release reached Maven Central without one — as `1.10.0` did, when `release.yml`
+still had no `publish-github` job.
+
+| Field | Value |
+| --- | --- |
+| `live-run` | **checked** — without it the action does nothing |
+| `version` | the released number, e.g. `1.10.0` |
+| `branch` | the release branch the tag is on, e.g. `release/1.10.0` |
+| `check-maven` | checked |
+
+**The release describes the tag, not the branch.** `bump-and-tag.bash` writes
+`version.txt` and tags it in the same run that publishes, so the tag *is* the
+version, and `gh release create --verify-tag` refuses a version that has none.
+`branch` only names where to cut a tag that does not exist yet, which here it
+always does.
+
+A tag alone is not proof, though — rehearsals are tagged too, so `1.10.0-rc4`
+is a real tag that was never published. Two checks run before the release is
+created: `version.txt` at the tag must equal `version`, and with `check-maven`
+the coordinate must already resolve from Maven Central. A mistyped version
+fails rather than announcing a release Maven never got. The pipeline leaves
+`check-maven` off, because the publish job that just ran is the evidence and a
+freshly released coordinate takes a while to appear on `repo1.maven.org`.
+
+This is the asymmetry worth remembering: the Maven publication cannot be
+undone, but a GitHub release can be edited (`gh release edit`) or removed
+(`gh release delete`, which leaves the tag in place), so running this again to
+correct a mistake costs nothing. The one effect that cannot be taken back is
+that publishing notifies everyone watching releases.
 
 ### After a release
 
@@ -304,7 +341,7 @@ policy, but because the repository that serves them is not on the path.
 
 ## How the pipeline works
 
-`release.yml` runs three jobs:
+`release.yml` runs four jobs:
 
 1. **`tag`** — `eclipse-zenoh/ci/create-release-branch` cuts the release branch,
    then `ci/scripts/bump-and-tag.bash` writes `version.txt`, optionally rewrites
@@ -317,6 +354,10 @@ policy, but because the repository that serves them is not on the path.
 3. **`publish-dokka`** — regenerates the API documentation and, on a live run
    only, deploys it to the `gh-pages` site README.md links to. The javadoc JAR
    attached to the Maven publications does not serve that site; this job does.
+4. **`publish-github`** — creates the GitHub release from the tag, on a live run
+   only. It calls `release-github.yml`, which is **also dispatchable on its
+   own** — see [Creating a GitHub release on its
+   own](#creating-a-github-release-on-its-own).
 
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.
@@ -351,7 +392,7 @@ Which `zenoh-flat-jni` *release* this SDK is built and published against is
 | --- | --- |
 | `CENTRAL_SONATYPE_TOKEN_USERNAME` / `_PASSWORD` | Central Portal user token |
 | `ORG_GPG_KEY_ID` / `_SUBKEY_ID` / `_PRIVATE_KEY` / `_PASSPHRASE` | signing |
-| `BOT_TOKEN_WORKFLOW` | release branch and tag push |
+| `BOT_TOKEN_WORKFLOW` | release branch, tag push, GitHub release |
 
 All are organization-level on `eclipse-zenoh`; nothing is configured per
 repository.
@@ -366,10 +407,10 @@ repository.
   snapshot repository and runs it — but a release goes to a staging repository
   and is not resolvable at that point, so nothing consumes a release candidate
   the way zenoh-flat-jni's own dry-run repository lets it consume one.
-- **No GitHub release is created.** Unlike zenoh-java, `release.yml` has no
-  `publish-github` job, so a release produces Maven artifacts, a tag and updated
-  documentation, but no GitHub release entry. This predates the flat-jni
-  transition and is left as it was.
+- **The GitHub release carries generated notes only.** The action uploads any
+  `*-standalone.zip` / `*-debian.zip` build artifacts it finds, and this
+  repository produces none, so the release is notes and source archives — the
+  binaries live on Maven Central.
 - **The Android artifact has no runtime test.** Only the JVM tests run
   (`jvmTest`); the Android variant is assembled and published unexercised.
 - **`zenoh-flat-jni` itself has not been released**, so the ordering constraint
@@ -386,3 +427,4 @@ repository.
 - [ ] For an Android release: the Android POM references
       `zenoh-flat-jni-android`, not the desktop coordinate.
 - [ ] The released coordinates resolve from Maven Central.
+- [ ] The GitHub release exists and its notes start at the previous release.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -291,11 +291,13 @@ mistake — wait, or re-run with `check-maven` off. The pipeline leaves it off,
 because it only reaches this job when `maven_publish` was on, so the publish job
 that just ran is the evidence.
 
-This is the asymmetry worth remembering: the Maven publication cannot be
-undone, but a GitHub release can be edited (`gh release edit`) or removed
-(`gh release delete`, which leaves the tag in place), so running this again to
-correct a mistake costs nothing. The one effect that cannot be taken back is
-that publishing notifies everyone watching releases.
+This is the asymmetry worth remembering: the Maven publication cannot be undone,
+but a GitHub release can be edited (`gh release edit`) or removed (`gh release
+delete`, which leaves the tag in place), so a mistake here costs nothing to
+correct. Note that correcting it means editing or deleting the release — this
+workflow runs `gh release create`, which fails rather than replacing one that
+already exists. The one effect that cannot be taken back is that publishing
+notifies everyone watching releases.
 
 ### After a release
 
@@ -371,8 +373,18 @@ previous version and there is no post-release commit to reconstruct.
 `update-release-project.yml` is driven by issues and pull requests, not by
 releases.
 
-Order does not matter, and both are safe to repeat: the documentation deploy
-overwrites, and a GitHub release can be edited or deleted. Verify with the
+Order does not matter. The documentation deploy is safe to repeat — it
+overwrites — but **Release (GitHub) is not**: it runs `gh release create`, which
+fails when a release already exists for the tag rather than replacing it. To
+change one that is already there, edit it directly:
+
+```bash
+gh release edit <version> --repo eclipse-zenoh/zenoh-kotlin --notes-file notes.md
+gh release delete <version> --repo eclipse-zenoh/zenoh-kotlin   # then re-run
+```
+
+`gh release delete` leaves the Git tag in place, so deleting and re-running is a
+valid way back — it just is not what re-running alone does. Verify with the
 [release checklist](#release-checklist) afterwards.
 
 ## Rehearsing before zenoh-flat-jni is released

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -193,6 +193,12 @@ builds and publishes.
 | `maven_publish` | checked — or uncheck for the very first run |
 | `github_release` | either — a rehearsal is not a live run, so no release is created regardless |
 
+Unchecking `maven_publish` also skips the GitHub release, whatever
+`github_release` says: with no upload there is nothing for a release to
+announce. To create one for a version already on Central, use
+[Release (GitHub)](#creating-a-github-release-on-its-own), which verifies
+instead of assuming.
+
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
 `live-run` publishes `<version>-SNAPSHOT` to the **mutable** snapshot repository
 and never runs `closeAndReleaseSonatypeStagingRepository`, while `maven_publish`
@@ -240,15 +246,25 @@ always does.
 A tag alone is not proof, though — rehearsals are tagged too, so `1.10.0-rc4`
 is a real tag that was never published. Two checks run before the release is
 created: `version.txt` at the tag must equal `version`, and with `check-maven`
-the coordinate must already resolve from Maven Central. A mistyped version
-fails rather than announcing a release Maven never got.
+the coordinate should resolve from Maven Central. Together they catch a
+mistyped version reaching a real but wrong tag.
 
-`check-maven` distinguishes *absent* from *unanswered*. A settled 404 fails the
-run; a timeout or a 5xx is reported and the release proceeds, because Central
-having a bad minute is not evidence about the version and should not block a
-release. A 404 immediately after a live release can also be propagation lag
-rather than a mistake — wait, or re-run with `check-maven` off. The pipeline
-leaves it off for that reason: the publish job that just ran is the evidence.
+Be precise about what they establish: **this tag is a release tag for this
+version, and this version exists on Central**. They do not tie the published
+artifact to this commit. Nothing published carries the commit it was built from
+— the POM has `<scm>` but no `<tag>` — so a tag force-moved onto a different
+commit carrying the same `version.txt` would still pass. Reaching that state
+means re-running a release whose version Central already accepted, which
+[If a release fails](#if-a-release-fails) says not to do.
+
+`check-maven` is **best-effort by design**, not a guarantee. It distinguishes
+*absent* from *unanswered*: a settled 404 fails the run, while a timeout or a
+5xx is reported as a warning and the release proceeds, because Central having a
+bad minute is not evidence about the version and should not block a release. A
+404 immediately after a live release can also be propagation lag rather than a
+mistake — wait, or re-run with `check-maven` off. The pipeline leaves it off,
+because it only reaches this job when `maven_publish` was on, so the publish job
+that just ran is the evidence.
 
 This is the asymmetry worth remembering: the Maven publication cannot be
 undone, but a GitHub release can be edited (`gh release edit`) or removed
@@ -430,9 +446,24 @@ policy, but because the repository that serves them is not on the path.
    only, deploys it to the `gh-pages` site README.md links to. The javadoc JAR
    attached to the Maven publications does not serve that site; this job does.
 4. **`publish-github`** — creates the GitHub release from the tag, on a live run
-   only. It calls `release-github.yml`, which is **also dispatchable on its
-   own** — see [Creating a GitHub release on its
-   own](#creating-a-github-release-on-its-own).
+   only, and only when `maven_publish` was on. It calls `release-github.yml`,
+   which is **also dispatchable on its own** — see [Creating a GitHub release on
+   its own](#creating-a-github-release-on-its-own).
+
+Jobs 3 and 4 both delegate to workflows that can be dispatched directly, which
+is what makes [recovery](#if-a-step-after-maven-central-fails) possible without
+re-running a release.
+
+`publish-github` calls `gh release create` itself rather than
+`eclipse-zenoh/ci/publish-crates-github`, which zenoh-java uses. The action
+would work — it needs no crate in the repository — but it reaches
+`build-crates-debian.ts` for one artifact regex, and that module initializes
+TOML at import, so every run first does `cargo +stable install
+toml-cli2@0.3.2 --force`: a Rust toolchain, a crates.io fetch and about 40
+seconds before it calls `gh`. A workflow whose purpose is to work when the
+release pipeline did not should not depend on crates.io. The two `gh` calls it
+makes for us are short enough to keep inline, and the artifact upload it also
+does is a no-op here.
 
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.
@@ -482,9 +513,8 @@ repository.
   snapshot repository and runs it — but a release goes to a staging repository
   and is not resolvable at that point, so nothing consumes a release candidate
   the way zenoh-flat-jni's own dry-run repository lets it consume one.
-- **The GitHub release carries generated notes only.** The action uploads any
-  `*-standalone.zip` / `*-debian.zip` build artifacts it finds, and this
-  repository produces none, so the release is notes and source archives — the
+- **The GitHub release carries generated notes only** — notes and the source
+  archives GitHub attaches itself. There are no build artifacts to add: the
   binaries live on Maven Central.
 - **The Android artifact has no runtime test.** Only the JVM tests run
   (`jvmTest`); the Android variant is assembled and published unexercised.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -234,6 +234,14 @@ the only configuration that exercises the credentials.
 `bump-and-tag.bash` tags whatever version it is handed, rehearsals included, so
 never give a rehearsal the number you intend to release.
 
+1.10.0 is the worked example: it was rehearsed as `1.10.0-rc1` through
+`1.10.0-rc4` before shipping, and all four tags are still on the remote
+alongside the real `1.10.0`, each with a `release/dry-run/<version>` branch. By
+name alone they are indistinguishable from a release tag. What separates them is
+Maven Central — `zenoh-kotlin:1.10.0` resolves, `1.10.0-rc4` is a 404 — which is
+why [Release (GitHub)](#creating-a-github-release-on-its-own) checks it rather
+than trusting the tag.
+
 ### The real release
 
 | Field | Value |

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -239,9 +239,14 @@ A tag alone is not proof, though — rehearsals are tagged too, so `1.10.0-rc4`
 is a real tag that was never published. Two checks run before the release is
 created: `version.txt` at the tag must equal `version`, and with `check-maven`
 the coordinate must already resolve from Maven Central. A mistyped version
-fails rather than announcing a release Maven never got. The pipeline leaves
-`check-maven` off, because the publish job that just ran is the evidence and a
-freshly released coordinate takes a while to appear on `repo1.maven.org`.
+fails rather than announcing a release Maven never got.
+
+`check-maven` distinguishes *absent* from *unanswered*. A settled 404 fails the
+run; a timeout or a 5xx is reported and the release proceeds, because Central
+having a bad minute is not evidence about the version and should not block a
+release. A 404 immediately after a live release can also be propagation lag
+rather than a mistake — wait, or re-run with `check-maven` off. The pipeline
+leaves it off for that reason: the publish job that just ran is the evidence.
 
 This is the asymmetry worth remembering: the Maven publication cannot be
 undone, but a GitHub release can be edited (`gh release edit`) or removed

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -283,7 +283,7 @@ They answer different questions, and it is worth being clear which does what:
 
 | Check | Question | Catches |
 | --- | --- | --- |
-| `version.txt` at the tag equals `version` | is this tag internally consistent? | a tag the release pipeline did not create, or one force-moved onto a commit belonging to another version |
+| `version.txt` at the tag equals the `version` you entered | is this tag internally consistent? | a tag the release pipeline did not create, or one force-moved onto a commit belonging to another version |
 | `check-maven` | was this version ever published? | a tag for a version that never shipped — **including rehearsal tags** |
 
 The first cannot do more than that, and it is worth understanding why: since

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -257,7 +257,7 @@ still had no `publish-github` job.
 
 | Field | Value |
 | --- | --- |
-| `live-run` | **checked** — without it the action does nothing |
+| `live-run` | **checked** — without it the workflow does nothing |
 | `version` | the released number, e.g. `1.10.0` |
 | `branch` | the release branch the tag is on, e.g. `release/1.10.0` |
 | `check-maven` | checked |

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -24,6 +24,7 @@ which covers them once for the whole stack.
   - [The real release](#the-real-release)
   - [Creating a GitHub release on its own](#creating-a-github-release-on-its-own)
   - [After a release](#after-a-release)
+  - [If a release fails](#if-a-release-fails)
 - [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released)
   - [Rehearsing the release workflow with a snapshot](#rehearsing-the-release-workflow-with-a-snapshot)
 - [How the pipeline works](#how-the-pipeline-works)
@@ -263,6 +264,45 @@ must reference a real `zenoh-flat-jni` release:
 curl -s https://repo1.maven.org/maven2/org/eclipse/zenoh/zenoh-kotlin/<version>/zenoh-kotlin-<version>.pom \
   | grep -A2 zenoh-flat-jni
 ```
+
+### If a release fails
+
+**The tag job runs first and pushes before anything is published.** So a run
+that dies in `publish` — an unresolvable dependency, a credential problem, a
+Central outage — still leaves the release branch and the tag pushed, for a
+version that has no artifacts anywhere. zenoh-java's failed run of 2026-08-10
+left exactly that: tag `1.10.0-rc1` and branch `release/dry-run/1.10.0-rc1`.
+
+Nothing downstream runs, though. `publish-dokka` and `publish-github` both
+`need` the publish job, so no documentation is deployed and **no GitHub release
+is created**. The whole visible residue is a tag pointing at unpublished code.
+
+**Retrying the same version is safe, as long as Central did not accept it.**
+Nothing accumulates across attempts, because every step is recreated rather than
+advanced:
+
+- `create-release-branch` does `git switch --force-create` and `git push
+  --force`, so the release branch is cut from `main` again, not extended;
+- `bump-and-tag.bash` therefore rewrites `version.txt` on a fresh branch, so its
+  bump commit applies cleanly on a retry;
+- the tag is `git tag --force` and `git push --force`.
+
+Fix the cause and run it again with the same number. Check the Central Portal
+first for a staging repository left open by the failed attempt, and drop it.
+
+**The one case where retrying the same number is wrong** is a run that got far
+enough for Central to accept the version. Maven Central is immutable: the
+version cannot be republished, and re-running would force-move the tag onto a
+new commit while Central keeps the artifact built from the old one — the tag and
+the published artifact would then describe different code. Move to a new version
+instead. This is also why the release number for a rehearsal must never be one
+you intend to release.
+
+If a version reached Central but produced no GitHub release, that is the
+recovery case for
+[Release (GitHub)](#creating-a-github-release-on-its-own) — and its
+`check-maven` check is what distinguishes it from this one, since a tag left by
+a failed publish resolves to nothing on Central and is refused.
 
 ## Rehearsing before zenoh-flat-jni is released
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -304,14 +304,22 @@ commit carrying the same `version.txt` would still pass. Reaching that state
 means re-running a release whose version Central already accepted, which
 [If a release fails](#if-a-release-fails) says not to do.
 
-`check-maven` is **best-effort by design**, not a guarantee. It distinguishes
-*absent* from *unanswered*: a settled 404 fails the run, while a timeout or a
-5xx is reported as a warning and the release proceeds, because Central having a
-bad minute is not evidence about the version and should not block a release. A
-404 immediately after a live release can also be propagation lag rather than a
-mistake — wait, or re-run with `check-maven` off. The pipeline leaves it off,
-because it only reaches this job when `maven_publish` was on, so the publish job
-that just ran is the evidence.
+`check-maven` **fails the run on anything but a success**, but it tells the two
+failures apart, because they need different responses:
+
+| Result | Meaning | What to do |
+| --- | --- | --- |
+| `404` | the version is wrong, or was never published | fix the version — or wait, if it was published minutes ago and has not propagated |
+| no answer | Central is unreachable | try again later, or untick `check-maven` to release without the check |
+
+Neither is a reason to continue. Proceeding unverified is the one thing this
+check exists to prevent, and it would do so exactly when verification was
+impossible — announcing a version that may not be published, in a notification
+that cannot be unsent. Releasing during an outage is a decision to make
+deliberately by unticking the box, not one the workflow should make silently.
+
+The pipeline leaves `check-maven` off, because it only reaches this job when
+`maven_publish` was on, so the publish job that just ran is the evidence.
 
 This is the asymmetry worth remembering: the Maven publication cannot be undone,
 but a GitHub release can be edited (`gh release edit`) or removed (`gh release

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -479,16 +479,23 @@ Jobs 3 and 4 both delegate to workflows that can be dispatched directly, which
 is what makes [recovery](#if-a-step-after-maven-central-fails) possible without
 re-running a release.
 
-`publish-github` calls `gh release create` itself rather than
-`eclipse-zenoh/ci/publish-crates-github`, which zenoh-java uses. The action
-would work — it needs no crate in the repository — but it reaches
-`build-crates-debian.ts` for one artifact regex, and that module initializes
-TOML at import, so every run first does `cargo +stable install
-toml-cli2@0.3.2 --force`: a Rust toolchain, a crates.io fetch and about 40
-seconds before it calls `gh`. A workflow whose purpose is to work when the
-release pipeline did not should not depend on crates.io. The two `gh` calls it
-makes for us are short enough to keep inline, and the artifact upload it also
-does is a no-op here.
+The release itself is created by `eclipse-zenoh/ci/publish-crates-github`, the
+shared action the rest of the Zenoh repositories use. Despite the name it
+publishes no crate: it creates the release from the tag with generated notes,
+then attaches any `*-standalone.zip` / `*-debian.zip` build archives. This
+repository produces none, so that half is inert and every release it has made
+here carries notes and GitHub's own source archives only.
+
+Two upstream defects are known and tracked in `eclipse-zenoh/ci`. Neither
+affects a normal release, and both are left upstream deliberately — a fix there
+reaches every Zenoh repository, whereas working around them here would fix one:
+
+- it installs `toml-cli2` from crates.io before running `gh`, costing roughly 40
+  seconds and a crates.io dependency this workflow has no use for;
+- it bounds the generated notes with the *newest* existing release rather than
+  the one preceding this version. Identical during a release; wrong only when
+  recovering a version after a newer one has already shipped, which produces
+  empty notes.
 
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -231,16 +231,9 @@ decides whether any upload happens at all. **A rehearsal with `maven_publish`
 checked performs a real, signed upload** — into the snapshot repository — and is
 the only configuration that exercises the credentials.
 
-`bump-and-tag.bash` tags whatever version it is handed, rehearsals included, so
-never give a rehearsal the number you intend to release.
-
-1.10.0 is the worked example: it was rehearsed as `1.10.0-rc1` through
-`1.10.0-rc4` before shipping, and all four tags are still on the remote
-alongside the real `1.10.0`, each with a `release/dry-run/<version>` branch. By
-name alone they are indistinguishable from a release tag. What separates them is
-Maven Central — `zenoh-kotlin:1.10.0` resolves, `1.10.0-rc4` is a 404 — which is
-why [Release (GitHub)](#creating-a-github-release-on-its-own) checks it rather
-than trusting the tag.
+`bump-and-tag.bash` tags whatever version it is handed, rehearsals included —
+1.10.0 was rehearsed as `1.10.0-rc1`…`rc4`, and those tags are still on the
+remote — so never give a rehearsal the number you intend to release.
 
 ### The real release
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -262,19 +262,32 @@ still had no `publish-github` job.
 | `branch` | the release branch the tag is on, e.g. `release/1.10.0` |
 | `check-maven` | checked |
 
-**The release describes the tag, not the branch.** `bump-and-tag.bash` writes
-`version.txt` and tags it in the same run that publishes, so the tag *is* the
-version, and `gh release create --verify-tag` refuses a version that has none.
-`branch` only names where to cut a tag that does not exist yet, which here it
-always does.
+**The release describes the tag, not the branch.** `ci/scripts/bump-and-tag.bash`
+— run by the `tag` job of the **Release** workflow, on the release branch just
+cut, before anything is published — writes `version.txt` and creates the tag in
+the same run. So the tag *is* the version, and `gh release create --verify-tag`
+refuses a version that has none. `branch` only names where to cut a tag that
+does not exist yet, which here it always does.
 
-A tag alone is not proof, though — rehearsals are tagged too, so `1.10.0-rc4`
-is a real tag that was never published. Two checks run before the release is
-created: `version.txt` at the tag must equal `version`, and with `check-maven`
-the coordinate should resolve from Maven Central. Together they catch a
-mistyped version reaching a real but wrong tag.
+A tag existing is not proof it was ever released, so two more checks run first.
+They answer different questions, and it is worth being clear which does what:
 
-Be precise about what they establish: **this tag is a release tag for this
+| Check | Question | Catches |
+| --- | --- | --- |
+| `version.txt` at the tag equals `version` | is this tag internally consistent? | a tag the release pipeline did not create, or one force-moved onto a commit belonging to another version |
+| `check-maven` | was this version ever published? | a tag for a version that never shipped — **including rehearsal tags** |
+
+The first cannot do more than that, and it is worth understanding why: since
+`bump-and-tag.bash` writes `version.txt` and tags it in the same run, the two
+agree by construction for every tag the pipeline produced. It is tautological
+for those. Its value is rejecting tags that did *not* come from the pipeline.
+
+In particular it does **not** catch a rehearsal. Rehearsal tags are
+self-consistent too — `version.txt` at `1.10.0-rc4` reads `1.10.0-rc4` — so
+they pass the first check and are stopped only by `check-maven`, which is why
+that box should stay ticked for a manual run.
+
+Be precise about what the pair establishes: **this tag is a release tag for this
 version, and this version exists on Central**. They do not tie the published
 artifact to this commit. Nothing published carries the commit it was built from
 — the POM has `<scm>` but no `<tag>` — so a tag force-moved onto a different

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -304,16 +304,17 @@ commit carrying the same `version.txt` would still pass. Reaching that state
 means re-running a release whose version Central already accepted, which
 [If a release fails](#if-a-release-fails) says not to do.
 
-`check-maven` requires the version to resolve from Maven Central, and reports
-its two failures differently, since they call for different responses:
+`check-maven` confirms the version is on Maven Central before the release is
+created, and reports the two ways that can fail separately:
 
-| Result | Meaning | What to do |
+| What happened | What it means | What to do |
 | --- | --- | --- |
-| `404` | the version is wrong, or was never published | fix the version — or wait, if it was published minutes ago and has not propagated |
-| no answer | Central is unreachable | try again later, or untick `check-maven` to release without the check |
+| Central says the version is not there | the version is wrong, or was never published | correct it — or wait, if the release is minutes old and has not propagated |
+| Central does not answer | Maven Central is unreachable | try again later, or untick `check-maven` to release without this check |
 
-The pipeline leaves `check-maven` off, because it only reaches this job when
-`maven_publish` was on, so the publish job that just ran is the evidence.
+The release pipeline switches `check-maven` off, because the publish job that
+just uploaded the version is proof enough. A manual run has no such proof, so
+`check-maven` defaults to on there.
 
 This is the asymmetry worth remembering: the Maven publication cannot be undone,
 but a GitHub release can be edited (`gh release edit`) or removed (`gh release

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -304,19 +304,13 @@ commit carrying the same `version.txt` would still pass. Reaching that state
 means re-running a release whose version Central already accepted, which
 [If a release fails](#if-a-release-fails) says not to do.
 
-`check-maven` **fails the run on anything but a success**, but it tells the two
-failures apart, because they need different responses:
+`check-maven` requires the version to resolve from Maven Central, and reports
+its two failures differently, since they call for different responses:
 
 | Result | Meaning | What to do |
 | --- | --- | --- |
 | `404` | the version is wrong, or was never published | fix the version — or wait, if it was published minutes ago and has not propagated |
 | no answer | Central is unreachable | try again later, or untick `check-maven` to release without the check |
-
-Neither is a reason to continue. Proceeding unverified is the one thing this
-check exists to prevent, and it would do so exactly when verification was
-impossible — announcing a version that may not be published, in a notification
-that cannot be unsent. Releasing during an outage is a decision to make
-deliberately by unticking the box, not one the workflow should make silently.
 
 The pipeline leaves `check-maven` off, because it only reaches this job when
 `maven_publish` was on, so the publish job that just ran is the evidence.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -172,6 +172,23 @@ Run the **Release** workflow from the Actions tab, from `main` or a release
 branch. The workflow creates the release branch, bumps the version, tags it,
 builds and publishes.
 
+Two checkboxes decide what it does. `live-run` chooses what "publish" *means*;
+`maven_publish` chooses whether the upload happens at all. Three combinations
+are accepted and the fourth is refused:
+
+| `live-run` | `maven_publish` | What it does |
+| --- | --- | --- |
+| ✗ | ✓ | **The normal rehearsal.** Uploads `<version>-SNAPSHOT` to the mutable snapshot repository — a real signed upload, so credentials and signing are exercised |
+| ✗ | ✗ | Assembles both publications and their POMs, uploads nothing |
+| ✓ | ✓ | **The real release.** Permanent and immutable on Maven Central |
+| ✓ | ✗ | **Refused** by the `tag` job — it would tag a version and publish nothing |
+
+Note that `maven_publish` defaults to checked, and that a rehearsal uploading a
+snapshot is normal rather than something to avoid: the snapshot repository is
+mutable, is not on consumers' default resolution path, and is cleaned after 90
+days. A rehearsal that uploads nothing cannot tell you whether the signing key
+and credentials work, which is the half of a release most likely to fail.
+
 ### Before the first run
 
 - **Secrets are already in place.** `CENTRAL_SONATYPE_TOKEN_*` and `ORG_GPG_*`
@@ -193,17 +210,18 @@ builds and publishes.
 | `maven_publish` | checked — or uncheck for the very first run |
 | `github_release` | either — a rehearsal is not a live run, so no release is created regardless |
 
-Unchecking `maven_publish` suppresses **everything outward-facing**, even on a
-live run: no GitHub release, whatever `github_release` says, and no
-documentation deploy. With no upload there is nothing to announce, and nothing
-whose documentation should replace the published site. Both jobs still run and
-still build, so the rehearsal value is intact — only the publishing stops.
+`maven_publish` suppresses the **upload**; it does not turn a run into a
+rehearsal. Combined with `live-run` it would cut the real release branch and
+force-push the real tag while publishing nothing — leaving a tag for a version
+that exists nowhere, which is what a
+[failed release](#if-a-release-fails) leaves behind. **The `tag` job rejects
+that combination before creating anything**, so `maven_publish` is only
+meaningful on a rehearsal.
 
-Note that `live-run` checked with `maven_publish` unchecked is *not* a
-rehearsal: it cuts the real release branch and force-pushes the real tag. It is
-a live release with the upload switched off. To publish a GitHub release or the
-documentation for a version already on Central, use the standalone workflows
-under [If a step after Maven Central
+Nothing is lost by that. To rehearse without uploading, uncheck `live-run`: the
+same build runs, and the branch it leaves is a prunable dry-run one. To publish
+a GitHub release or the documentation for a version already on Central, use the
+standalone workflows under [If a step after Maven Central
 fails](#if-a-step-after-maven-central-fails), which verify rather than assume.
 
 `live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
@@ -223,7 +241,7 @@ never give a rehearsal the number you intend to release.
 | `live-run` | **checked** |
 | `version` | the release number |
 | `zenoh-flat-jni-version` | the zenoh-flat-jni release to build against — **must already be on Central** |
-| `maven_publish` | checked |
+| `maven_publish` | checked — the only accepted value on a live run |
 | `github_release` | checked |
 
 Supplying `zenoh-flat-jni-version` rewrites `zenohFlatJniVersion` in

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -283,13 +283,14 @@ They answer different questions, and it is worth being clear which does what:
 
 | Check | Question | Catches |
 | --- | --- | --- |
-| `version.txt` at the tag equals the `version` you entered | is this tag internally consistent? | a tag the release pipeline did not create, or one force-moved onto a commit belonging to another version |
+| `version.txt` at the tag equals the `version` you entered | do the tag and its commit name the same version? | a tag pointing at a commit whose `version.txt` names a different version |
 | `check-maven` | was this version ever published? | a tag for a version that never shipped — **including rehearsal tags** |
 
-The first cannot do more than that, and it is worth understanding why: since
-`bump-and-tag.bash` writes `version.txt` and tags it in the same run, the two
-agree by construction for every tag the pipeline produced. It is tautological
-for those. Its value is rejecting tags that did *not* come from the pipeline.
+The first is narrower than it looks. `bump-and-tag.bash` writes `version.txt`
+and tags it in the same run, so every tag the pipeline produced passes. What it
+rejects is a tag pointing at a commit whose `version.txt` names a different
+version — moved onto another version's commit, or created there. A tag made by
+hand on the right commit passes, so this does not establish who made the tag.
 
 In particular it does **not** catch a rehearsal. Rehearsal tags are
 self-consistent too — `version.txt` at `1.10.0-rc4` reads `1.10.0-rc4` — so
@@ -385,12 +386,13 @@ point must therefore be recoverable on its own, and each piece is:
 | Maven Central coordinates | `publish` | nothing to do — immutable and done |
 | Release branch and tag | `tag` | already pushed, before `publish` ran |
 | GitHub release | `publish-github` | **Release (GitHub)**, [above](#creating-a-github-release-on-its-own) |
-| `gh-pages` documentation | `publish-dokka` | **Publish (Dokka)**, `live-run` checked and `branch` set to the tag |
+| `gh-pages` documentation | `publish-dokka` | **Publish (Dokka)**, `live-run` checked and `branch` set to `refs/tags/<version>` |
 
 Both recovery workflows need `live-run` **checked** — unchecked, each builds and
 verifies but changes nothing, which is also how you rehearse one. Give
-`publish-dokka` the released tag as `branch`, not a branch name: the release
-branch can move afterwards, the tag cannot.
+`publish-dokka` the released tag as `branch`, written in full as
+`refs/tags/<version>`: the release branch can move afterwards, the tag cannot,
+and a bare `1.10.0` would resolve to a branch of that name before the tag.
 
 Nothing else in a release is one-shot. `main` is deliberately untouched —
 `version.txt` is bumped on the release branch only, so `main` keeps naming the

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -25,6 +25,7 @@ which covers them once for the whole stack.
   - [Creating a GitHub release on its own](#creating-a-github-release-on-its-own)
   - [After a release](#after-a-release)
   - [If a release fails](#if-a-release-fails)
+  - [If a step after Maven Central fails](#if-a-step-after-maven-central-fails)
 - [Rehearsing before zenoh-flat-jni is released](#rehearsing-before-zenoh-flat-jni-is-released)
   - [Rehearsing the release workflow with a snapshot](#rehearsing-the-release-workflow-with-a-snapshot)
 - [How the pipeline works](#how-the-pipeline-works)
@@ -303,6 +304,35 @@ recovery case for
 [Release (GitHub)](#creating-a-github-release-on-its-own) — and its
 `check-maven` check is what distinguishes it from this one, since a tag left by
 a failed publish resolves to nothing on Central and is refused.
+
+### If a step after Maven Central fails
+
+Once Central accepts the version, **re-running the release is not an option**:
+the version cannot be republished, and the tag would force-move onto a different
+commit than the artifact was built from. Everything the pipeline does after that
+point must therefore be recoverable on its own, and each piece is:
+
+| Produced | By | Recover with |
+| --- | --- | --- |
+| Maven Central coordinates | `publish` | nothing to do — immutable and done |
+| Release branch and tag | `tag` | already pushed, before `publish` ran |
+| GitHub release | `publish-github` | **Release (GitHub)**, [above](#creating-a-github-release-on-its-own) |
+| `gh-pages` documentation | `publish-dokka` | **Publish (Dokka)**, `live-run` checked and `branch` set to the tag |
+
+Both recovery workflows need `live-run` **checked** — unchecked, each builds and
+verifies but changes nothing, which is also how you rehearse one. Give
+`publish-dokka` the released tag as `branch`, not a branch name: the release
+branch can move afterwards, the tag cannot.
+
+Nothing else in a release is one-shot. `main` is deliberately untouched —
+`version.txt` is bumped on the release branch only, so `main` keeps naming the
+previous version and there is no post-release commit to reconstruct.
+`update-release-project.yml` is driven by issues and pull requests, not by
+releases.
+
+Order does not matter, and both are safe to repeat: the documentation deploy
+overwrites, and a GitHub release can be edited or deleted. Verify with the
+[release checklist](#release-checklist) afterwards.
 
 ## Rehearsing before zenoh-flat-jni is released
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -262,12 +262,18 @@ still had no `publish-github` job.
 | `branch` | the release branch the tag is on, e.g. `release/1.10.0` |
 | `check-maven` | checked |
 
-**The release describes the tag, not the branch.** `ci/scripts/bump-and-tag.bash`
-— run by the `tag` job of the **Release** workflow, on the release branch just
-cut, before anything is published — writes `version.txt` and creates the tag in
-the same run. So the tag *is* the version, and `gh release create --verify-tag`
-refuses a version that has none. `branch` only names where to cut a tag that
-does not exist yet, which here it always does.
+**The release describes the tag, not the branch.** `version` is a release number
+such as `1.10.0`, and it is used **verbatim as the Git tag name**:
+`ci/scripts/bump-and-tag.bash` — run by the `tag` job of the **Release**
+workflow, on the release branch just cut, before anything is published — writes
+`version.txt` and then runs `git tag --force "$version"`. Tag name and version
+string are the same characters.
+
+That is what makes `version` sufficient on its own. `gh release create` takes the
+tag name as its argument, so the workflow passes `version` straight through, and
+`--verify-tag` aborts unless a tag of exactly that name already exists on the
+remote. `branch` only names where to cut a tag that does not exist yet, which
+here it always does.
 
 A tag existing is not proof it was ever released, so two more checks run first.
 They answer different questions, and it is worth being clear which does what:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -511,16 +511,10 @@ then attaches any `*-standalone.zip` / `*-debian.zip` build archives. This
 repository produces none, so that half is inert and every release it has made
 here carries notes and GitHub's own source archives only.
 
-Two upstream defects are known and tracked in `eclipse-zenoh/ci`. Neither
+Two upstream defects are known and tracked in
+[eclipse-zenoh/ci#470](https://github.com/eclipse-zenoh/ci/issues/470). Neither
 affects a normal release, and both are left upstream deliberately — a fix there
-reaches every Zenoh repository, whereas working around them here would fix one:
-
-- it installs `toml-cli2` from crates.io before running `gh`, costing roughly 40
-  seconds and a crates.io dependency this workflow has no use for;
-- it bounds the generated notes with the *newest* existing release rather than
-  the one preceding this version. Identical during a release; wrong only when
-  recovering a version after a newer one has already shipped, which produces
-  empty notes.
+reaches every Zenoh repository, whereas working around them here would fix one.
 
 Publishing goes through `io.github.gradle-nexus.publish-plugin` to the Central
 Portal, signed with the organization GPG key, exactly as in zenoh-flat-jni.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -270,10 +270,12 @@ workflow, on the release branch just cut, before anything is published — write
 `version.txt` and then runs `git tag --force "$version"`. Tag name and version
 string are the same characters.
 
-That is what makes `version` sufficient on its own. `gh release create` takes the
-tag name as its argument, so the workflow passes `version` straight through, and
-`--verify-tag` aborts unless a tag of exactly that name already exists on the
-remote. `branch` only names where to cut a tag that does not exist yet, which
+That is what makes `version` sufficient on its own. `publish-crates-github`
+creates the release by invoking `gh release create`, the GitHub CLI command for
+the job, which takes the tag name as its first argument — so the workflow passes
+`version` straight through. The action always passes that command's
+`--verify-tag` flag, which makes it abort unless a tag of exactly that name
+already exists on the remote. `branch` only names where to cut a tag that does not exist yet, which
 here it always does.
 
 A tag existing is not proof it was ever released, so two more checks run first.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -41,10 +41,15 @@ org.eclipse.zenoh:zenoh-kotlin:<version>          the JVM artifact
 org.eclipse.zenoh:zenoh-kotlin-android:<version>  the Android artifact
 ```
 
-Both are **pure JVM/Kotlin**. This repository contains no Rust and builds no
-native libraries: they arrive inside the zenoh-flat-jni artifacts, already
-cross-compiled and verified by that repository's own release, and a consumer of
-`zenoh-kotlin` gets them transitively.
+Both are **pure JVM/Kotlin**. Neither carries Rust or a native library: those
+arrive inside the zenoh-flat-jni artifacts, already cross-compiled and verified
+by that repository's own release, and a consumer of `zenoh-kotlin` gets them
+transitively.
+
+The repository does hold one Rust crate, `zenoh-flat-jni-pin` (`Cargo.toml` and
+`ci/pin.rs`). It builds nothing that ships. It exists so the zenoh-flat-jni
+commit this SDK is tested against is recorded in `Cargo.lock`, which is the file
+the organization's lockfile sync knows how to move.
 
 `zenoh-flat-jni` is itself a Kotlin Multiplatform library, so this SDK declares
 **one** dependency on its root coordinate and Gradle resolves the variant
@@ -224,7 +229,9 @@ a GitHub release or the documentation for a version already on Central, use the
 standalone workflows under [If a step after Maven Central
 fails](#if-a-step-after-maven-central-fails), which verify rather than assume.
 
-`live-run` and `maven_publish` behave exactly as in zenoh-flat-jni: unchecking
+`live-run` and `maven_publish` mean what they mean in zenoh-flat-jni, with one
+difference: this repository refuses a live run with `maven_publish` off, which
+zenoh-flat-jni's release workflow still accepts. Unchecking
 `live-run` publishes `<version>-SNAPSHOT` to the **mutable** snapshot repository
 and never runs `closeAndReleaseSonatypeStagingRepository`, while `maven_publish`
 decides whether any upload happens at all. **A rehearsal with `maven_publish`
@@ -570,9 +577,10 @@ repository.
 
 ## Known gaps
 
-- **The rewritten release path has never run.** The workflows were repaired for
-  a repository that no longer contains Rust; no rehearsal has yet exercised
-  them.
+- **The recovery and gating paths added for this have never run.** The release
+  path itself has: 1.10.0 published from it on 2026-08-14. What is unexercised
+  is the standalone recovery of a GitHub release or of the documentation, and
+  the refusal of a live run with uploads disabled.
 - **No consumer test before a *release*.** Every snapshot publication is followed
   by `ci/consumer-smoke-test`, which resolves the published artifact from the
   snapshot repository and runs it — but a release goes to a staging repository
@@ -583,8 +591,11 @@ repository.
   binaries live on Maven Central.
 - **The Android artifact has no runtime test.** Only the JVM tests run
   (`jvmTest`); the Android variant is assembled and published unexercised.
-- **`zenoh-flat-jni` itself has not been released**, so the ordering constraint
-  above has never been satisfied for a real release.
+- **The snapshot still pins a `zenoh-flat-jni` version that was never
+  released.** `gradle.properties` names `1.9.0-kotlin-SNAPSHOT`, our own copy;
+  `zenoh-flat-jni:1.9.0` is not on Maven Central and never was. `1.10.0` is, so
+  the ordering constraint is satisfiable now, but a live release still has to be
+  given that version explicitly.
 
 ## Release checklist
 


### PR DESCRIPTION
## The problem

The [1.10.0 release run](https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/31831372420) published `org.eclipse.zenoh:zenoh-kotlin:1.10.0` to Maven Central, but created [no GitHub release](https://github.com/eclipse-zenoh/zenoh-kotlin/releases). The newest release is still 1.9.0.

`release.yml` has no job that creates one. The zenoh-flat transition removed that job (#669, commit 8bdd60f7) on the belief that `eclipse-zenoh/ci/publish-crates-github` — the shared action the Zenoh repositories use — publishes Rust crates and would fail in a repository that has none. The action needs no crate here, and zenoh-java has been running it throughout.

## How the workflows fit together

`release.yml` is the entry point. It calls the other three as jobs; nothing calls `release.yml`.

```text
release.yml                          Actions → Release
  ├─ tag                             inline: create-release-branch, bump-and-tag.bash
  ├─ publish        ──► publish.yml            Maven Central
  ├─ publish-dokka  ──► publish-dokka.yml      gh-pages          ← also runs alone
  └─ publish-github ──► release-github.yml     GitHub release    ← also runs alone

ci.yml                               push to main
  └─ publish_snapshot_package ──► publish.yml  snapshot upload
```

`publish-dokka` and `publish-github` both wait for `publish`, so neither announces a version whose upload failed. `publish.yml` calls nothing, and `ci.yml` calls it on every push to `main` — which is why creating a GitHub release belongs in `release-github.yml` and not there.

The two workflows marked *also runs alone* are what this pull request is mostly about.

Two inputs of `release.yml` decide what a run does, and both predate this pull request. `live-run` separates a rehearsal from a real release. `maven_publish`, on by default, switches off the upload to Maven Central.

## What this changes

### The GitHub release job comes back, in a workflow that also runs alone

`release.yml` calls the new `.github/workflows/release-github.yml` as its last job. You can also start that workflow yourself from the Actions tab.

Running that workflow alone is the point. A Maven Central publication cannot be withdrawn, so when a release reaches Central without a GitHub release, the fix must not require re-running the tag and publish jobs. zenoh-java keeps these steps inline in `release.yml`, which cannot be started on its own.

### Two checks before the release is created

`version` is an input of `release-github.yml`: a release number such as `1.10.0`. `ci/scripts/bump-and-tag.bash` passes it verbatim to `git tag`, so one string names both the release and its tag. `publish-crates-github` passes `--verify-tag` to `gh release create`, which refuses a version with no tag of that name. Two further checks run first:

| Check | Question | Rejects |
| --- | --- | --- |
| `version.txt` at the tag equals the `version` input | do the tag and its commit name the same version? | a tag pointing at a commit whose `version.txt` names a different version |
| `check-maven` | was this version published? | a tag for a version that never shipped |

The first check is narrow. `bump-and-tag.bash` writes `version.txt` and creates the tag in the same run, so every tag the pipeline made passes. What it rejects is a tag pointing at a commit whose `version.txt` names a different version. A tag made by hand on the right commit passes, so it does not establish who made the tag.

`check-maven` is what rejects a **rehearsal tag**. A rehearsal is a release run under a throwaway version number — 1.10.0 was rehearsed as `1.10.0-rc1`…`rc4` — and it pushes a real tag. Rehearsal tags are self-consistent, so they pass the first check.

`check-maven` reports its two failures separately, because they call for different responses: Central says the version is not there, or Central does not answer. The release pipeline switches `check-maven` off, because the publish job that just uploaded the version is proof enough. A manual run has no such proof, so `check-maven` defaults to on there.

### The documentation deploy also runs alone now

`publish-dokka.yml` builds the API documentation with Dokka and deploys it to `gh-pages`, the branch GitHub serves as a website. That workflow declared a manual trigger with no inputs, so a manual run received nothing: the deploy step was skipped and the build used `main`. Starting the workflow by hand built the site and discarded it, while reporting success.

`publish-dokka.yml` now declares those two inputs for manual runs as well. `branch` is required, so a manual run cannot overwrite the published documentation with the unreleased API from `main`.

### Nothing is announced when the upload is skipped

`publish.yml` gates only its upload step on `maven_publish`, so the publish job succeeds whether or not anything was uploaded. Both the GitHub release and the documentation deploy are now gated on `maven_publish` as well. Without that, a live run with uploads disabled would announce a version that was never published.

`release.yml` also gains `github_release` (default on), so a Maven-only release stays expressible.

### A live run with uploads disabled is rejected

`maven_publish` suppresses the upload; it does not turn a run into a rehearsal. A live run with `maven_publish` off cut the real release branch and force-pushed the real tag while publishing nothing, leaving a tag for a version that exists nowhere. The `tag` job now refuses that combination before creating anything.

Nothing is lost. Rehearsing without uploading is `live-run` off, which runs the same build and leaves a disposable dry-run branch.

| `live-run` | `maven_publish` | |
| --- | --- | --- |
| off | on | rehearsal — a real signed upload of `<version>-SNAPSHOT` to the mutable snapshot repository |
| off | off | build the artifacts, upload nothing |
| on | on | the real release |
| on | off | **refused** |

### PUBLISHING.md

The document listed the missing GitHub release as a known gap, said the pipeline ran three jobs, and credited `BOT_TOKEN_WORKFLOW` with only branch and tag pushes. All corrected, and four sections added: the table above, how to create a GitHub release on its own, what a failed release leaves behind, and how to recover a step that failed after Maven Central.

## Recovery after Maven Central has accepted a version

At that point the release cannot be re-run: the version cannot be republished, and re-running would force-move the tag onto a different commit than the artifact was built from. So each remaining step recovers on its own:

| Produced by | Recover with |
| --- | --- |
| `publish` | nothing — Maven Central is immutable and done |
| `tag` | nothing — the branch and tag were pushed before `publish` ran |
| `publish-github` | **Release (GitHub)**, started from the Actions tab |
| `publish-dokka` | **Publish (Dokka)**, started from the Actions tab, with `branch` set to `refs/tags/<version>` |

`main` is deliberately untouched by a release — `version.txt` is bumped on the release branch only — so no post-release commit needs reconstructing.

## Recovering 1.10.0

**Actions → Release (GitHub) → Run workflow**, with *Use workflow from* set to `main`. That selector chooses which copy of the workflow file runs; it does not affect what is released.

| Field | Value |
| --- | --- |
| `live-run` | on — without it the workflow does nothing |
| `version` | `1.10.0` |
| `branch` | `release/1.10.0` |
| `check-maven` | on |

Checked against the repository: the tag `1.10.0` exists and points at `4ae99df`, the head of `release/1.10.0`; `version.txt` at that tag reads `1.10.0`; `zenoh-kotlin:1.10.0` resolves from Maven Central; and the newest release is `1.9.0`, so the notes will span `1.9.0...1.10.0`. `.github/release.yml` — the notes configuration, a different file from the `release.yml` workflow — sorts generated notes into labelled sections and is present at that tag, so the result will look like [zenoh-java's 1.10.0 notes](https://github.com/eclipse-zenoh/zenoh-java/releases/tag/1.10.0).

Getting this wrong is cheap. A GitHub release can be edited with `gh release edit`, or removed with `gh release delete`, which leaves the tag in place. Note that correcting one means editing or deleting it — `publish-crates-github` runs `gh release create`, which fails rather than replacing an existing release. The only effect that cannot be taken back is that publishing notifies watchers.

## Compared with zenoh-java

The action and its five inputs are identical. Around it:

| | zenoh-java | here |
| --- | --- | --- |
| Structure | inline steps in `release.yml` | a separate workflow that also runs alone |
| Runner | `macos-latest` | `ubuntu-latest` — nothing here needs macOS |
| Guards | none | `version.txt`, `check-maven`, and the refused combination |
| Skip switch | none | `github_release` |

zenoh-java needs all of these, plus the same fix to its own `publish-dokka.yml`, which has the identical empty manual trigger. Kept out of this pull request to hold it to one repository.

## Two upstream defects

Filed as [eclipse-zenoh/ci#470](https://github.com/eclipse-zenoh/ci/issues/470):

- `publish-crates-github` builds its `gh` command by joining strings and runs the result through a shell, with the bot token in the environment. The `version` and `branch` it is given therefore reach `sh -c`. This workflow constrains both to plain ref characters before calling the action; the action itself should use the argument-array helper it already has.
- It installs a Rust helper from crates.io before it can run `gh`, on every invocation.
- It bounds generated notes with the newest release rather than the one preceding the version being released.

Only the first affects safety, and the constraint above closes it here. The second costs every release about 40 seconds but changes nothing it produces. The third is confined to creating a release for a version that is not the newest, so it does not affect the 1.10.0 recovery.

Neither is worked around here: a fix upstream reaches every Zenoh repository, a workaround here reaches one.

## Testing

Not run end to end — this is release machinery, and running it live is the situation being fixed. What was checked:

- `check-maven` against a published version, a rehearsal version, and an unreachable host.
- All four workflow files parse. The job graph is `tag → publish → {publish-dokka, publish-github}`. `markdownlint-cli2` is clean on `PUBLISHING.md`.
- The action's behaviour was read from its source in `eclipse-zenoh/ci` and confirmed against a zenoh-java release job log. Both defects in #470 came from that reading.

## Review

Thanks to @Copilot and Codex, who found six issues between them. All are addressed; the comments below have the detail.
