### PR TITLE
Follow the generated Kotlin's private handles and nullable returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,9 +1366,8 @@ checksum = "00af7901ba50898c9e545c24d5c580c96a982298134e8037d8978b6594782c07"
 
 [[package]]
 name = "kotlin-codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba9922acc37e9f38dce99ed966c2777c09a458566b75932bdcf2a1717b46b1"
+version = "0.3.0"
+source = "git+https://github.com/milyin/kotlin-codegen.git?branch=ctor-vis-and-file-annotations#a3d6b26d8a201214e105829177bb6756990c3f78"
 
 [[package]]
 name = "lazy_static"
@@ -1932,12 +1931,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "prebindgen"
+version = "0.5.0"
+source = "git+https://github.com/milyin/prebindgen.git?branch=main#04cfe414888cf92bd0dbdab8d23a20d12f88c1c8"
+dependencies = [
+ "if_rust_version",
+ "itertools",
+ "konst 0.3.17",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "roxygen",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "toml",
+]
+
+[[package]]
 name = "prebindgen-flat"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61ae0f7eea879df64ed40837b4111b09084533648c71a7b5f528ec67063cb05"
+source = "git+https://github.com/milyin/prebindgen.git?branch=main#04cfe414888cf92bd0dbdab8d23a20d12f88c1c8"
 dependencies = [
- "prebindgen",
+ "prebindgen 0.5.0 (git+https://github.com/milyin/prebindgen.git?branch=main)",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1946,12 +1963,11 @@ dependencies = [
 [[package]]
 name = "prebindgen-jni"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa15d7c2b59f15249fa5fd0f97beeff2785587e6046e749c1bbcc15cc00340a9"
+source = "git+https://github.com/milyin/prebindgen.git?branch=main#04cfe414888cf92bd0dbdab8d23a20d12f88c1c8"
 dependencies = [
  "jni 0.21.1",
  "kotlin-codegen",
- "prebindgen",
+ "prebindgen 0.5.0 (git+https://github.com/milyin/prebindgen.git?branch=main)",
  "prebindgen-jni-runtime",
  "prebindgen-registry",
  "proc-macro2",
@@ -1962,8 +1978,7 @@ dependencies = [
 [[package]]
 name = "prebindgen-jni-runtime"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e1c12ad857da45a8c6977a4b5b3395b4f53c8082239dcde925f3b964144531"
+source = "git+https://github.com/milyin/prebindgen.git?branch=main#04cfe414888cf92bd0dbdab8d23a20d12f88c1c8"
 dependencies = [
  "jni 0.21.1",
 ]
@@ -1974,7 +1989,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4ec12eecd2811fd1395a20bdd40e3740026be0603bf2812172445fc524c98e7"
 dependencies = [
- "prebindgen",
+ "prebindgen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
  "rand 0.9.5",
@@ -1986,11 +2001,10 @@ dependencies = [
 [[package]]
 name = "prebindgen-registry"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a3be56008ab6c8631ea5d6b0df8f7a9142134d39befe6e695679a7d618a12a"
+source = "git+https://github.com/milyin/prebindgen.git?branch=main#04cfe414888cf92bd0dbdab8d23a20d12f88c1c8"
 dependencies = [
  "itertools",
- "prebindgen",
+ "prebindgen 0.5.0 (git+https://github.com/milyin/prebindgen.git?branch=main)",
  "prebindgen-flat",
  "prettyplease",
  "proc-macro2",
@@ -3994,10 +4008,10 @@ dependencies = [
 [[package]]
 name = "zenoh-flat"
 version = "1.9.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh-flat.git?branch=main#5819b4997db7d71b495a36b76d5d8a9da58bbbfd"
+source = "git+https://github.com/eclipse-zenoh/zenoh-flat.git?branch=main#acd7d716d71b74f0795d00cc5411fcf23a5de16c"
 dependencies = [
  "android-logd-logger",
- "prebindgen",
+ "prebindgen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prebindgen-proc-macro",
  "serde_yaml",
  "tracing",
@@ -4008,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "zenoh-flat-jni"
 version = "1.9.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=main#8331748be65346d796d04ed1f03f046c714e9028"
+source = "git+https://github.com/eclipse-zenoh/zenoh-flat-jni.git?branch=deps%2Fprebindgen-main#59878aa8dca6087c421f90a48e88b52a2f641179"
 dependencies = [
  "jni 0.21.1",
  "konst 0.3.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,11 @@ path = "ci/pin.rs"
 [dependencies]
 # No features: the pin must resolve the same way the real build does, and the
 # real build is zenoh-flat-jni's own `cargo build`.
-zenoh-flat-jni = { git = "https://github.com/eclipse-zenoh/zenoh-flat-jni.git", branch = "main" }
+#
+# TEMPORARY: on the branch of eclipse-zenoh/zenoh-flat-jni#45 rather than on
+# `main`, because the call-site changes in this pull request compile only
+# against the generated Kotlin that pull request produces. Restore
+# `branch = "main"` and re-resolve before merging — a branch that no longer
+# exists resolves to nothing, and while this points at a branch the lockfile
+# sync bot cannot move the pin.
+zenoh-flat-jni = { git = "https://github.com/eclipse-zenoh/zenoh-flat-jni.git", branch = "deps/prebindgen-main" }

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Config.kt
@@ -140,7 +140,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * Returns the default config.
          */
         fun default(): Config {
-            return Config(JniConfig.newDefault(throwZError0))
+            return Config(JniConfig.newDefault(throwZError0)!!)
         }
 
         /**
@@ -160,7 +160,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromFile(path: Path): Result<Config> =
-            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 JniConfig.newFromFile(path.toString(), onBindingError, onError)
             }.map { Config(it) }
 
@@ -200,7 +200,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
         // and JSON is a subset of JSON5, so every input accepted here before is
         // still accepted and parses to the same config.
         fun fromJson(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 JniConfig.newFromJson5(config, onBindingError, onError)
             }.map { Config(it) }
 
@@ -237,7 +237,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromJson5(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 JniConfig.newFromJson5(config, onBindingError, onError)
             }.map { Config(it) }
 
@@ -270,7 +270,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
          * @return A result with the [Config].
          */
         fun fromYaml(config: String): Result<Config> =
-            zCall({ JniConfig(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 JniConfig.newFromYaml(config, onBindingError, onError)
             }.map { Config(it) }
 
@@ -298,7 +298,7 @@ class Config internal constructor(internal val jniConfig: JniConfig) {
      * Returns the json value associated to the [key].
      */
     fun getJson(key: String): Result<String> {
-        return zCall({ "" }) { onBindingError, onError -> jniConfig.getJson(key, onBindingError, onError) }
+        return zCall { onBindingError, onError -> jniConfig.getJson(key, onBindingError, onError) }
     }
 
     /**

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Session.kt
@@ -22,22 +22,13 @@ import io.zenoh.exceptions.zCallUnit
 import io.zenoh.handlers.Callback
 import io.zenoh.handlers.ChannelHandler
 import io.zenoh.handlers.Handler
-import io.zenoh.jni.config.Config as JniConfig
-import io.zenoh.jni.config.ZenohId as JniZenohId
-import io.zenoh.jni.keyexpr.KeyExpr as JniKeyExpr
-import io.zenoh.jni.pubsub.AdvancedPublisher as JniAdvancedPublisher
-import io.zenoh.jni.pubsub.AdvancedSubscriber as JniAdvancedSubscriber
 import io.zenoh.jni.pubsub.CacheConfig as JniCacheConfig
 import io.zenoh.jni.pubsub.HistoryConfig as JniHistoryConfig
 import io.zenoh.jni.pubsub.MissDetectionConfig as JniMissDetectionConfig
-import io.zenoh.jni.pubsub.Publisher as JniPublisher
 import io.zenoh.jni.pubsub.RecoveryConfig as JniRecoveryConfig
 import io.zenoh.jni.query.Selector as JniSelector
 import io.zenoh.jni.pubsub.RecoveryMode as JniRecoveryMode
 import io.zenoh.jni.pubsub.RepliesConfig as JniRepliesConfig
-import io.zenoh.jni.pubsub.Subscriber as JniSubscriber
-import io.zenoh.jni.query.Querier as JniQuerier
-import io.zenoh.jni.query.Queryable as JniQueryable
 import io.zenoh.jni.session.Session as JniSession
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.keyexpr.jniHandle
@@ -686,7 +677,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
      */
     fun declareKeyExpr(keyExpr: String): Result<KeyExpr> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniKeyExpr(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareKeyexpr(keyExpr, onBindingError, onError)
         }
             .map { KeyExpr(keyExpr, it) }
@@ -1122,7 +1113,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         reliability: Reliability
     ): Result<Publisher> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniPublisher(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declarePublisher(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 encoding.jniSel, encoding.jniId, encoding.jniSchema, encoding.jniHandle,
@@ -1157,7 +1148,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
                 JniRepliesConfig(it.repliesQoS.priority.jni, it.repliesQoS.congestionControl.jni, it.repliesQoS.express)
             )
         }
-        return zCall({ JniAdvancedPublisher(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareAdvancedPublisher(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 encoding.jniSel, encoding.jniId, encoding.jniSchema, encoding.jniHandle,
@@ -1195,7 +1186,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
             }
             JniRecoveryConfig(mode, null)
         }
-        return zCall({ JniAdvancedSubscriber(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareAdvancedSubscriber(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 sampleCallbackOf { callback.run(it) },
@@ -1214,7 +1205,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         receiver: R
     ): Result<Subscriber<R>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniSubscriber(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareSubscriber(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 sampleCallbackOf { callback.run(it) },
@@ -1233,7 +1224,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         complete: Boolean
     ): Result<Queryable<R>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniQueryable(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareQueryable(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 complete,
@@ -1254,7 +1245,7 @@ class Session private constructor(private val config: Config) : AutoCloseable {
         acceptReplies: ReplyKeyExpr
     ): Result<Querier> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall({ JniQuerier(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             session.declareQuerier(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 target.jni, consolidation.jni,
@@ -1330,28 +1321,28 @@ class Session private constructor(private val config: Config) : AutoCloseable {
 
     internal fun zid(): Result<ZenohId> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall0({ JniZenohId(ByteArray(0)) }) { session.getZid(it) }
+        return zCall0 { session.getZid(it) }
             .map { ZenohId(it.bytes) }
     }
 
     internal fun getPeersId(): Result<List<ZenohId>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall0({ emptyList() }) { session.getPeersZid(it) }
+        return zCall0 { session.getPeersZid(it) }
             .map { ids -> ids.map { ZenohId(it.bytes) } }
     }
 
     internal fun getRoutersId(): Result<List<ZenohId>> {
         val session = jniSession ?: return Result.failure(sessionClosedException)
-        return zCall0({ emptyList() }) { session.getRoutersZid(it) }
+        return zCall0 { session.getRoutersZid(it) }
             .map { ids -> ids.map { ZenohId(it.bytes) } }
     }
 
     /** Launches the session through the jni session, returning the [Session] on success. */
     private fun launch(): Result<Session> {
         // `open` consumes its config; clone so the user's [Config] stays reusable.
-        val cloned = zCall0({ JniConfig(0L) }) { config.jniConfig.newClone(it) }
+        val cloned = zCall0 { config.jniConfig.newClone(it) }
             .getOrElse { return Result.failure(it) }
-        return zCall({ JniSession(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             JniSession.open(cloned, onBindingError, onError)
         }
             .map {

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/Zenoh.kt
@@ -21,7 +21,6 @@ import io.zenoh.exceptions.zCall
 import io.zenoh.handlers.Callback
 import io.zenoh.handlers.ChannelHandler
 import io.zenoh.handlers.Handler
-import io.zenoh.jni.scouting.Scout as JniScout
 import io.zenoh.scouting.Hello
 import io.zenoh.scouting.Scout
 import kotlinx.coroutines.channels.Channel
@@ -100,7 +99,7 @@ object Zenoh {
         whatAmI: Set<WhatAmI>,
         config: Config?
     ): Result<Scout<R>> {
-        return zCall({ JniScout(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             // Argument preparation stays inside the captured block: an empty
             // [whatAmI] makes `reduce` throw, which must surface as
             // Result.failure (the pre-flat API contract).

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/bytes/ZBytes.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/bytes/ZBytes.kt
@@ -73,7 +73,7 @@ class ZBytes private constructor(
         get() = eager ?: synchronized(this) {
             eager ?: run {
                 val h = handle!!
-                val b = h.toBytes(throwZError0)
+                val b = h.toBytes(throwZError0)!!
                 eager = b
                 handle = null
                 h.close()
@@ -104,7 +104,7 @@ class ZBytes private constructor(
      * the caller does not close it.
      */
     internal fun toZZBytes(): JniZBytes =
-        JniZBytes.newFromVec(bytes, throwZError0)
+        JniZBytes.newFromVec(bytes, throwZError0)!!
 
     /** Returns the internal byte representation of the [ZBytes]. */
     fun toBytes(): ByteArray = bytes

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/exceptions/ResultHandlers.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/exceptions/ResultHandlers.kt
@@ -30,11 +30,11 @@ import io.zenoh.jni.JniErrorHandler
  *    binding-layer failure — UTF-8 decode, closed handle, …) and `onError`
  *    (the typed domain [ErrorHandler], the decomposed zenoh error message).
  *    The [zCall]/[zCallUnit] helpers supply BOTH — each records the error
- *    into one local and, where the wrapper's return type demands a value,
- *    produces a throw-away *sentinel* (a born-closed handle such as
- *    `Session(0L)`, an empty list, …). No exception is ever in flight for a
- *    native error. Binding-only-fallible wrappers ([zCall0]/[zCallUnit0]) take
- *    just the single [JniErrorHandler].
+ *    into one local and returns `null`, which a wrapper whose return type is a
+ *    reference accepts (prebindgen #419); nothing has to be fabricated to
+ *    satisfy the signature. No exception is ever in flight for a native error.
+ *    Binding-only-fallible wrappers ([zCall0]/[zCallUnit0]) take just the
+ *    single [JniErrorHandler].
  * 2. **JVM-side exceptions** — argument preparation (collection ops, …),
  *    user-supplied conversions (`IntoZBytes.into()`), and class
  *    initialization (native-library loading) can throw before or around the
@@ -49,8 +49,9 @@ import io.zenoh.jni.JniErrorHandler
  * call has returned.
  */
 
-/** Fallible flat call returning `Unit` — no sentinel needed. The wrapper takes
- * both channels (`onBindingError`, `onError`); each records into [err]. */
+/** Fallible flat call returning `Unit` — the handlers have nothing to return.
+ * The wrapper takes both channels (`onBindingError`, `onError`); each records
+ * into [err]. */
 internal inline fun zCallUnit(
     crossinline block: (JniErrorHandler<Unit>, ErrorHandler<Unit>) -> Unit
 ): Result<Unit> {
@@ -76,48 +77,51 @@ internal inline fun zCallUnit0(crossinline block: (JniErrorHandler<Unit>) -> Uni
 }
 
 /**
- * Fallible flat call returning `T`; [sentinel] runs only on the error path to
- * satisfy the wrapper's return type (its value is discarded). The wrapper takes
- * both channels (`onBindingError`, `onError`); each records into [err] and
- * produces the sentinel.
+ * Fallible flat call returning a reference-shaped `T`. Each handler records the
+ * error into [err] and declines by returning `null`, which a wrapper whose
+ * return type is a reference accepts. The wrapper takes both channels
+ * (`onBindingError`, `onError`).
+ *
+ * A `null` with no error recorded means the wrapper returned no value and
+ * reported no failure. No wrapper called from here does that — every one of
+ * them returns a value the Rust side always produces — so it is reported as a
+ * failure rather than passed on as a null.
  */
-internal inline fun <T> zCall(
-    crossinline sentinel: () -> T,
-    crossinline block: (JniErrorHandler<T>, ErrorHandler<T>) -> T
+internal inline fun <T : Any> zCall(
+    crossinline block: (JniErrorHandler<T?>, ErrorHandler<T?>) -> T?
 ): Result<T> {
     var err: ZError? = null
     val outcome = runCatching {
         block(
             JniErrorHandler { je ->
                 err = ZError(je ?: "native binding error")
-                sentinel()
+                null
             },
             ErrorHandler { message ->
                 err = ZError(message)
-                sentinel()
+                null
             },
         )
     }
     err?.let { return Result.failure(it) }
-    return outcome
+    return outcome.mapCatching { it ?: throw ZError("native call returned no value and reported no error") }
 }
 
-/** Binding-only-fallible flat call returning `T`; [sentinel] as in [zCall]. */
-internal inline fun <T> zCall0(
-    crossinline sentinel: () -> T,
-    crossinline block: (JniErrorHandler<T>) -> T
+/** Binding-only-fallible flat call returning a reference-shaped `T`, otherwise as [zCall]. */
+internal inline fun <T : Any> zCall0(
+    crossinline block: (JniErrorHandler<T?>) -> T?
 ): Result<T> {
     var err: ZError? = null
     val outcome = runCatching {
         block(
             JniErrorHandler { je ->
                 err = ZError(je ?: "native binding error")
-                sentinel()
+                null
             }
         )
     }
     err?.let { return Result.failure(it) }
-    return outcome
+    return outcome.mapCatching { it ?: throw ZError("native call returned no value and reported no error") }
 }
 
 /** Domain handler for non-[Result] contexts: throws [ZError] (safe — runs after

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/keyexpr/KeyExpr.kt
@@ -85,7 +85,7 @@ class KeyExpr internal constructor(
      * [io.zenoh.jni.query.Selector]) with no string arm to select.
      */
     internal fun intoJniHandle(): JniKeyExpr =
-        cloneHandle() ?: JniKeyExpr.newTryFrom(keyExpr, throwZError0, throwZError)
+        cloneHandle() ?: JniKeyExpr.newTryFrom(keyExpr, throwZError0, throwZError)!!
 
     /**
      * Run [body] with a native handle: the declared handle when present,
@@ -95,7 +95,7 @@ class KeyExpr internal constructor(
     private inline fun <R> withHandle(body: (JniKeyExpr) -> R): R {
         val h = jniKeyExpr
         if (h != null) return body(h)
-        val tmp = JniKeyExpr.newTryFrom(keyExpr, throwZError0, throwZError)
+        val tmp = JniKeyExpr.newTryFrom(keyExpr, throwZError0, throwZError)!!
         try {
             return body(tmp)
         } finally {
@@ -112,12 +112,12 @@ class KeyExpr internal constructor(
          * [Result.failure].
          */
         private inline fun fromProbe(
-            crossinline makeProbe: (JniErrorHandler<JniKeyExpr>, ErrorHandler<JniKeyExpr>) -> JniKeyExpr
+            crossinline makeProbe: (JniErrorHandler<JniKeyExpr?>, ErrorHandler<JniKeyExpr?>) -> JniKeyExpr?
         ): Result<KeyExpr> =
-            zCall({ JniKeyExpr(0L) }) { onBindingError, onError -> makeProbe(onBindingError, onError) }
+            zCall { onBindingError, onError -> makeProbe(onBindingError, onError) }
                 .mapCatching { probe ->
                     try {
-                        KeyExpr(probe.asStr(throwZError0))
+                        KeyExpr(probe.asStr(throwZError0)!!)
                     } finally {
                         probe.close()
                     }
@@ -139,7 +139,7 @@ class KeyExpr internal constructor(
          * @return a [Result] with the [KeyExpr] in case of success.
          */
         fun tryFrom(keyExpr: String): Result<KeyExpr> =
-            zCall({ JniKeyExpr(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 JniKeyExpr.newTryFrom(keyExpr, onBindingError, onError)
             }
                 .map { probe ->
@@ -190,7 +190,7 @@ class KeyExpr internal constructor(
     fun relationTo(other: KeyExpr): SetIntersectionLevel = withHandle { h ->
         val raw = other.jniKeyExpr?.let { h.relationTo(it, throwZError0) }
             ?: h.relationTo(other.keyExpr, throwZError0)
-        SetIntersectionLevel.fromInt(raw.value)
+        SetIntersectionLevel.fromInt(raw!!.value)
     }
 
     /**

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/liveliness/Liveliness.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/liveliness/Liveliness.kt
@@ -20,8 +20,6 @@ import io.zenoh.exceptions.zCallUnit
 import io.zenoh.handlers.Callback
 import io.zenoh.handlers.ChannelHandler
 import io.zenoh.handlers.Handler
-import io.zenoh.jni.liveliness.LivelinessToken as JniLivelinessToken
-import io.zenoh.jni.pubsub.Subscriber as JniSubscriber
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.keyexpr.jniHandle
 import io.zenoh.keyexpr.jniSel
@@ -51,7 +49,7 @@ class Liveliness internal constructor(private val session: Session) {
      */
     fun declareToken(keyExpr: KeyExpr): Result<LivelinessToken> {
         val jniSession = session.jniSession ?: return Result.failure(Session.sessionClosedException)
-        return zCall({ JniLivelinessToken(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             jniSession.livelinessDeclareToken(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 onBindingError, onError
@@ -189,7 +187,7 @@ class Liveliness internal constructor(private val session: Session) {
         history: Boolean
     ): Result<Subscriber<R>> {
         val jniSession = session.jniSession ?: return Result.failure(Session.sessionClosedException)
-        return zCall({ JniSubscriber(0L) }) { onBindingError, onError ->
+        return zCall { onBindingError, onError ->
             jniSession.livelinessDeclareSubscriber(
                 keyExpr.jniSel, keyExpr.jniStr, keyExpr.cloneHandle(),
                 history,

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/AdvancedPublisher.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/AdvancedPublisher.kt
@@ -16,6 +16,8 @@ package io.zenoh.pubsub
 
 import io.zenoh.annotations.Unstable
 import io.zenoh.exceptions.ZError
+import io.zenoh.exceptions.throwZError
+import io.zenoh.exceptions.throwZError0
 import io.zenoh.exceptions.zCall
 import io.zenoh.exceptions.zCallUnit
 import io.zenoh.keyexpr.KeyExpr
@@ -33,7 +35,6 @@ import io.zenoh.handlers.MatchingHandler
 import io.zenoh.jni.VoidCallback
 import io.zenoh.jni.boolCallback
 import io.zenoh.jni.pubsub.AdvancedPublisher as JniAdvancedPublisher
-import io.zenoh.jni.pubsub.MatchingListener as JniMatchingListener
 import io.zenoh.session.SessionDeclaration
 import kotlinx.coroutines.channels.Channel
 
@@ -158,7 +159,7 @@ class AdvancedPublisher internal constructor(
                 p.declareBackgroundMatchingListener(jniCallback, jniOnClose, onBindingError, onError)
             }.map { MatchingListener(null) }
         } else {
-            zCall({ JniMatchingListener(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 p.declareMatchingListener(jniCallback, jniOnClose, onBindingError, onError)
             }.map { MatchingListener(it) }
         }
@@ -171,9 +172,11 @@ class AdvancedPublisher internal constructor(
      */
     fun getMatchingStatus(): Result<Boolean> {
         val p = jniAdvancedPublisher ?: return invalidPublisherResult()
-        return zCall({ false }) { onBindingError, onError ->
-            p.matchingStatus(onBindingError, onError)
-        }
+        // Not zCall: a `Boolean` return keeps its non-null contract, so its
+        // handlers have no `null` to decline with. They throw instead, and
+        // runCatching turns that into the Result — throwing from a handler is
+        // safe, it runs after the native call has returned.
+        return runCatching { p.matchingStatus(throwZError0, throwZError) }
     }
 
     /** Performs a PUT operation on the publisher's [keyExpr] with the specified [payload]. */

--- a/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/AdvancedSubscriber.kt
+++ b/zenoh-kotlin/src/commonMain/kotlin/io/zenoh/pubsub/AdvancedSubscriber.kt
@@ -26,8 +26,6 @@ import io.zenoh.handlers.SampleMissChannelHandler
 import io.zenoh.handlers.SampleMissHandler
 import io.zenoh.jni.VoidCallback
 import io.zenoh.jni.pubsub.AdvancedSubscriber as JniAdvancedSubscriber
-import io.zenoh.jni.pubsub.SampleMissListener as JniSampleMissListener
-import io.zenoh.jni.pubsub.Subscriber as JniSubscriber
 import io.zenoh.keyexpr.KeyExpr
 import io.zenoh.sample.Sample
 import io.zenoh.sampleCallbackOf
@@ -205,7 +203,7 @@ class AdvancedSubscriber<R> internal constructor(
                 s.declareBackgroundDetectPublishersSubscriber(jniCallback, jniOnClose, history, onBindingError, onError)
             }.map { Subscriber(keyExpr, receiver, null) }
         } else {
-            zCall({ JniSubscriber(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 s.declareDetectPublishersSubscriber(jniCallback, jniOnClose, history, onBindingError, onError)
             }.map { Subscriber(keyExpr, receiver, it) }
         }
@@ -331,7 +329,7 @@ class AdvancedSubscriber<R> internal constructor(
                 s.declareBackgroundSampleMissListener(jniCallback, jniOnClose, onBindingError, onError)
             }.map { SampleMissListener(null) }
         } else {
-            zCall({ JniSampleMissListener(0L) }) { onBindingError, onError ->
+            zCall { onBindingError, onError ->
                 s.declareSampleMissListener(jniCallback, jniOnClose, onBindingError, onError)
             }.map { SampleMissListener(it) }
         }

--- a/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZDeserialize.kt
+++ b/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZDeserialize.kt
@@ -1,7 +1,7 @@
 package io.zenoh.ext
 
 import io.zenoh.bytes.ZBytes
-import io.zenoh.exceptions.zCall0
+import io.zenoh.exceptions.throwZError0
 import io.zenoh.jni.bytes.SerializationCodec
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -80,9 +80,11 @@ inline fun <reified T : Any> zDeserialize(zbytes: ZBytes): Result<T> =
  * Implementation of [zDeserialize]: builds a [SerializationCodec.SerdeType] from the [KType]
  * and runs the **pure-Kotlin** [SerializationCodec] deserializer — no JNI crossing. Supports
  * the Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types in
- * addition to the signed/collection types. Wired through [zCall0] exactly like
- * a generated wrapper.
+ * addition to the signed/collection types. [SerializationCodec] is handwritten
+ * rather than generated, so its error handler keeps a non-null result type and
+ * cannot decline with `null`: it throws instead, and `runCatching` turns that
+ * into the [Result].
  */
 @PublishedApi
 internal fun zDeserializeImpl(zbytes: ZBytes, type: KType): Result<Any> =
-    zCall0<Any>({ Unit }) { SerializationCodec.deserialize(zbytes.toBytes(), serdeTypeOf(type), it) }
+    runCatching { SerializationCodec.deserialize(zbytes.toBytes(), serdeTypeOf(type), throwZError0) }

--- a/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZSerialize.kt
+++ b/zenoh-kotlin/src/jvmAndAndroidMain/kotlin/io/zenoh/ext/ZSerialize.kt
@@ -1,7 +1,7 @@
 package io.zenoh.ext
 
 import io.zenoh.bytes.ZBytes
-import io.zenoh.exceptions.zCall0
+import io.zenoh.exceptions.throwZError0
 import io.zenoh.jni.bytes.SerializationCodec
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -79,11 +79,12 @@ inline fun <reified T : Any> zSerialize(t: T): Result<ZBytes> = zSerializeImpl(t
  * Implementation of [zSerialize]: builds a [SerializationCodec.SerdeType] from the [KType]
  * and runs the **pure-Kotlin** [SerializationCodec] serializer — no JNI crossing. Supports
  * the Kotlin-specific `UByte`/`UShort`/`UInt`/`ULong`/`Pair`/`Triple` types in
- * addition to the signed/collection types. Wired through [zCall0] exactly like
- * a generated wrapper: the error-sink callback carries a serializer failure, and
- * `serdeTypeOf` failures surface through the same `runCatching`.
+ * addition to the signed/collection types. [SerializationCodec] is handwritten
+ * rather than generated, so its error handler keeps a non-null result type and
+ * cannot decline with `null`: it throws instead, and `runCatching` — which also
+ * catches a `serdeTypeOf` failure — turns that into the [Result].
  */
 @PublishedApi
 internal fun zSerializeImpl(t: Any, type: KType): Result<ZBytes> =
-    zCall0({ ByteArray(0) }) { SerializationCodec.serialize(t, serdeTypeOf(type), it) }
+    runCatching { SerializationCodec.serialize(t, serdeTypeOf(type), throwZError0) }
         .map { ZBytes.from(it) }


### PR DESCRIPTION
This SDK compiles against the Kotlin that zenoh-flat-jni generates. That generated
Kotlin changes shape in
[eclipse-zenoh/zenoh-flat-jni#45](https://github.com/eclipse-zenoh/zenoh-flat-jni/pull/45),
which moves the generator — the `prebindgen-*` crates — from the released 0.5.0 to the
current tip of [milyin/prebindgen](https://github.com/milyin/prebindgen) `main`. Two of
the generator changes are a source-level break for every consumer, this SDK included.
This pull request pins that zenoh-flat-jni branch and fixes the call sites.

## The two breaks

**Handle constructors are private now**
([milyin/prebindgen#404](https://github.com/milyin/prebindgen/pull/404)). A generated
handle class used to expose a public `(Long)` constructor, so safe Kotlin could invent a
pointer and hand it to native code. It is `private` now, reachable only through an
`internal` factory. This SDK used it deliberately: every `zCall(…)` passed a *sentinel*
lambda — `{ JniPublisher(0L) }`, a born-closed throw-away handle — for the error handler
to return, because the handler had to produce a value of the wrapper's return type even
when there was no value.

**Reference returns are nullable now**
([milyin/prebindgen#419](https://github.com/milyin/prebindgen/pull/419)). A wrapper whose
return is reference-shaped returns a nullable type, and so does the error handler that
goes with it: the handler may decline by returning `null` instead of fabricating
something. Primitive and unsigned returns keep their exact non-null contract.

The second break removes the need the first one was serving. The sentinels are not
replaced here — they are deleted.

## What changed

**`ResultHandlers.kt`** — `zCall` and `zCall0` lose their `sentinel` parameter. Their
handlers record the error and return `null`, and both take a `T : Any` so they still hand
back a `Result<T>` rather than a `Result<T?>`: a `null` with no error recorded cannot come
from any wrapper called here, so it becomes a `Result.failure` rather than propagating
into the public API as a null. `zCallUnit`/`zCallUnit0` are untouched — a `Unit` handler
never had anything to return. Every call site drops its sentinel lambda; the imports that
existed only to name the sentinel types go with them.

**Two call sites keep a non-null contract and so cannot use `zCall`:**

* `AdvancedPublisher.getMatchingStatus()` — a `Boolean` return, which #419 deliberately
  leaves non-null, so its handlers have no `null` to decline with.
* `zSerializeImpl` / `zDeserializeImpl` — these call `SerializationCodec`, which is
  handwritten Kotlin in zenoh-flat-jni rather than generated, so no generator change
  touches its signature.

Both now use the existing `throwZError`/`throwZError0` handlers inside `runCatching`,
which produces the same `Result`. Throwing from a handler is safe and already documented
as such in `ResultHandlers.kt`: the handler runs after the native call has returned.

**`!!` where a handler throws.** `KeyExpr`, `Config.default()` and `ZBytes` call wrappers
with `throwZError0`, so a null cannot arrive — but the signature now permits one.
`KeyExpr.fromProbe` also widens the handler types of its `makeProbe` parameter to match
the wrappers it is given.

No public API of this SDK changes: every affected function still returns `Result<T>` or a
non-null value.

## The pin, and what has to happen before merge

`Cargo.toml` points at the `deps/prebindgen-main` branch of zenoh-flat-jni instead of
`main`, and `Cargo.lock` records that branch's commit. That is what
`./gradlew jvmTest -PuseLocalJni=true` — the CI build — checks out and compiles.

**Before merging: restore `branch = "main"` in `Cargo.toml` and re-resolve.** zenoh-flat-jni#45
must merge first. Two reasons this cannot ship as it stands: a branch deleted after merge
resolves to nothing, and while the manifest names a branch other than `main` the shared
lockfile-sync bot cannot move the pin. The manifest says so in place.


## The chain

Three repositories move together, in this order — each step's dependency must be on
`main` before the next resolves it:

1. eclipse-zenoh/zenoh-flat#96 — the capture writer, so one build resolves one prebindgen
2. eclipse-zenoh/zenoh-flat-jni#45 — the reader, and the Kotlin it regenerates
3. eclipse-zenoh/zenoh-kotlin#710 — the SDK call sites that regenerated Kotlin breaks

zenoh-flat#96 is not a dependency of this pull request's contents — it changes no
generated code — but it is part of the same move and merges first.

## Verification

`./gradlew jvmTest -PlocalJniDir=../zenoh-flat-jni` against a checkout of zenoh-flat-jni#45,
which is the same compilation CI runs, sourced from a local directory rather than the
pinned commit.
